### PR TITLE
updated @cdklabs/generative-ai-cdk-constructs version to 0.1.234

### DIFF
--- a/examples/chat-demo-app/package-lock.json
+++ b/examples/chat-demo-app/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-lambda-powertools/logger": "^2.3.0",
         "@aws-sdk/client-bedrock-runtime": "^3.621.0",
         "@aws-sdk/core": "^3.621.0",
-        "@cdklabs/generative-ai-cdk-constructs": "^0.1.205",
+        "@cdklabs/generative-ai-cdk-constructs": "^0.1.234",
         "aws-cdk-lib": "^2.147.3",
         "aws-lambda": "^1.0.7",
         "constructs": "^10.0.0",
@@ -1696,14 +1696,14 @@
       "dev": true
     },
     "node_modules/@cdklabs/generative-ai-cdk-constructs": {
-      "version": "0.1.217",
-      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.217.tgz",
-      "integrity": "sha512-Fg/5u4UKWzvlwK2JkGBKrF1NOOOUQwQqK9G/ac1tOtJ82WXHD7QCo21XrYBd3r6tbyJGtpcfhvGC0ba1rzWOSQ==",
+      "version": "0.1.234",
+      "resolved": "https://registry.npmjs.org/@cdklabs/generative-ai-cdk-constructs/-/generative-ai-cdk-constructs-0.1.234.tgz",
+      "integrity": "sha512-zQo8GcyQLaT1Il6E8VQWCD/0ZssHylS44L3JWo5mec12fTy6VhAKzZ4/rQCgT3ZlAGpanRD6Q+ZInbWthW/S3w==",
       "bundleDependencies": [
         "deepmerge"
       ],
       "dependencies": {
-        "cdk-nag": "^2.28.162",
+        "cdk-nag": "^2.28.174",
         "deepmerge": "^4.3.1"
       },
       "engines": {
@@ -4013,9 +4013,9 @@
       ]
     },
     "node_modules/cdk-nag": {
-      "version": "2.28.163",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.163.tgz",
-      "integrity": "sha512-CKTUq5YzU4PYxz4MbhBMy9bC/dsEsnv2Ftty00bBjrBCokE1WSr4ILeYHX28RAHqunLLmtZKhf3cDDpx1VUqGA==",
+      "version": "2.28.175",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.175.tgz",
+      "integrity": "sha512-8CdL5D2/56E9ieEnY1e479wcJ6rIX58ZarEdq2gkpRXWFWJ/JVVfdcc4eWPVE6YL7dyPea+V/XsktyrPIDoOuw==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.116.0",
         "constructs": "^10.0.5"

--- a/examples/chat-demo-app/package.json
+++ b/examples/chat-demo-app/package.json
@@ -27,7 +27,7 @@
     "@aws-lambda-powertools/logger": "^2.3.0",
     "@aws-sdk/client-bedrock-runtime": "^3.621.0",
     "@aws-sdk/core": "^3.621.0",
-    "@cdklabs/generative-ai-cdk-constructs": "^0.1.205",
+    "@cdklabs/generative-ai-cdk-constructs": "^0.1.234",
     "aws-cdk-lib": "^2.147.3",
     "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",


### PR DESCRIPTION
updated @cdklabs/generative-ai-cdk-constructs to latest version 0.1.234 (it fixed the issue regarding guadrail config being empty and generating an error from Bedrock Agent service = > https://github.com/awslabs/generative-ai-cdk-constructs/releases/tag/v0.1.219)