### PR TITLE
Convert conversation message to dict when we use function tool

### DIFF
--- a/python/src/multi_agent_orchestrator/agents/bedrock_llm_agent.py
+++ b/python/src/multi_agent_orchestrator/agents/bedrock_llm_agent.py
@@ -132,7 +132,7 @@ class BedrockLLMAgent(Agent):
                     final_message = bedrock_response
 
                 max_recursions -= 1
-                converse_cmd['messages'] = conversation
+                converse_cmd['messages'] = conversation_to_dict(conversation)
 
             return final_message
 


### PR DESCRIPTION
Missing conversion object ConversationMessage to dict object before invoking Bedrock API

<!-- markdownlint-disable MD041 MD043 -->
**Issue number: https://github.com/awslabs/multi-agent-orchestrator/issues/36

## Summary

### Changes

> Please provide a summary of what's being changed

- python/src/multi_agent_orchestrator/agents/bedrock_llm_agent.py

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
