### PR TITLE
Correct Project Name Reference In Feature Request Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,12 @@
 name: Feature request
-description: Suggest an idea for CloudFront Hosting Toolkit
+description: Suggest an idea for multi-agent-orchestrator
 title: "Feature request: TITLE"
 labels: ["feature-request", "triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to suggest an idea to the CloudFront Hosting Toolkit project.
+        Thank you for taking the time to suggest an idea to the multi-agent-orchestrator project.
 
         *Future readers*: Please react with 👍 and your use case to help us understand customer demand.
   - type: textarea


### PR DESCRIPTION
Change "CloudFront Hosting Toolkit" to "multi-agent-orchestrator"

<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**  42

## Summary

Change "CloudFront Hosting Toolkit" to "multi-agent-orchestrator" in Feature Request Issue Template

### Changes

> Correcting the incorrect project name references in the Feature Request Issue Template.

### User experience

> Before: The project name was incorrect. After: The project name is correct.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested

<details>
<summary>Is this a breaking change?</summary>

This is not a breaking change.

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
