### PR TITLE
fix broken link

### DIFF
--- a/docs/src/content/docs/general/faq.md
+++ b/docs/src/content/docs/general/faq.md
@@ -73,7 +73,7 @@ The Multi-Agent Orchestrator framwork supports multiple storage options:
 
 ##### Is there a way to check if the agents I've added to the orchestrator don't overlap?
 
-Agent overlapping can be an issue which may lead to incorrect routing. The framework provides a tool called [Agent Overlap Analysis](/multi-agent-orchestrator/advanced-features/agent-overlap) that allows you to gain insights about potential overlapping between agents.
+Agent overlapping can be an issue which may lead to incorrect routing. The framework provides a tool called [Agent Overlap Analysis](/multi-agent-orchestrator/cookbook/monitoring/agent-overlap/) that allows you to gain insights about potential overlapping between agents.
 
 It's important to understand that routing to agents is done using a combination of user input, agent descriptions, and the conversation history of all agents. Therefore, crafting precise and distinct agent descriptions is crucial for optimal performance.
 

--- a/docs/src/content/docs/general/faq.md
+++ b/docs/src/content/docs/general/faq.md
@@ -73,7 +73,7 @@ The Multi-Agent Orchestrator framwork supports multiple storage options:
 
 ##### Is there a way to check if the agents I've added to the orchestrator don't overlap?
 
-Agent overlapping can be an issue which may lead to incorrect routing. The framework provides a tool called [Agent Overlap Analysis](/multi-agent-orchestrator/cookbook/monitoring/agent-overlap/) that allows you to gain insights about potential overlapping between agents.
+Agent overlapping can be an issue which may lead to incorrect routing. The framework provides a tool called [Agent Overlap Analysis](/multi-agent-orchestrator/cookbook/monitoring/agent-overlap) that allows you to gain insights about potential overlapping between agents.
 
 It's important to understand that routing to agents is done using a combination of user input, agent descriptions, and the conversation history of all agents. Therefore, crafting precise and distinct agent descriptions is crucial for optimal performance.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** n/a

## Summary

### Changes

The change updates the URL for the Agent Overlap Analysis tool to reflect its new location in the documentation.

### User experience

Can follow link in FAQ :) 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ X ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

no

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
