### PR TITLE
Split MAO python package dependency into feature (anthropic and openai) and removed Bedrock dependency in Classifier and Orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ To quickly get a feel for the Multi-Agent Orchestrator, check out our [Demo App]
 Get hands-on experience with the Multi-Agent Orchestrator through our diverse set of examples:
 
 - **Ready-to-run Scripts**: Start locally with our collection of standalone scripts in both Python and TypeScript.
-- **Demo Applications**: 
-  - [Chat Demo App](https://awslabs.github.io/multi-agent-orchestrator/cookbook/examples/chat-demo-app/): 
+- **Demo Applications**:
+  - [Chat Demo App](https://awslabs.github.io/multi-agent-orchestrator/cookbook/examples/chat-demo-app/):
     - Explore multiple specialized agents handling various domains like travel, weather, math, and health
   - [E-commerce Support Simulator](https://awslabs.github.io/multi-agent-orchestrator/cookbook/examples/ecommerce-support-simulator/): Experience AI-powered customer support with:
     - Automated response generation for common queries
@@ -83,8 +83,8 @@ Get hands-on experience with the Multi-Agent Orchestrator through our diverse se
   - [`chat-chainlit-app`](https://github.com/awslabs/multi-agent-orchestrator/tree/main/examples/chat-chainlit-app): Chat application built with Chainlit
   - [`fast-api-streaming`](https://github.com/awslabs/multi-agent-orchestrator/tree/main/examples/fast-api-streaming): FastAPI implementation with streaming support
   - [`text-2-structured-output`](https://github.com/awslabs/multi-agent-orchestrator/tree/main/examples/text-2-structured-output): Natural Language to Structured Data
-  
-  
+
+
 All examples are available in both Python and TypeScript implementations. Check out our [documentation](https://awslabs.github.io/multi-agent-orchestrator/) for comprehensive guides on setting up and using the Multi-Agent Orchestrator!
 
 
@@ -192,7 +192,7 @@ if (response.streaming == true) {
 
 ### Python Version
 
-#### Installation
+#### Core Installation
 
 ```bash
 # Optional: Set up a virtual environment
@@ -201,7 +201,7 @@ source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 pip install multi-agent-orchestrator
 ```
 
-#### Usage
+#### Default Usage
 
 Here's an equivalent Python example demonstrating the use of the Multi-Agent Orchestrator with a Bedrock LLM Agent and a Lex Bot Agent:
 
@@ -288,6 +288,19 @@ These examples showcase:
 2. Integration of a Lex Bot Agent for specialized tasks (in this case, travel-related queries).
 3. The orchestrator's ability to route requests to the most appropriate agent based on the input.
 4. Handling of both streaming and non-streaming responses from different types of agents.
+
+### Working with Anthropic or OpenAI
+If you want to use Anthropic or OpenAI for classifier and/or agents, make sure to install the multi-agent-orchestrator with the relevant extra feature.
+```bash
+pip install multi-agent-orchestrator[anthropic]
+pip install multi-agent-orchestrator[openai]
+```
+
+### Full package installation
+For a complete installation (including Anthropic and OpenAi):
+```bash
+pip install multi-agent-orchestrator[all]
+```
 
 
 ## 🤝 Contributing

--- a/docs/src/content/docs/classifiers/built-in/anthropic-classifier.mdx
+++ b/docs/src/content/docs/classifiers/built-in/anthropic-classifier.mdx
@@ -16,6 +16,11 @@ The Anthropic Classifier extends the abstract `Classifier` class and uses the An
 
 ### Basic Usage
 
+⚠️ To use Anthropic Classifier, make sure you have installed the multi-agent-orchestrator with anthropic feature (see [python installation](/multi-agent-orchestrator/general/quickstart#-get-started))
+```bash
+pip install multi-agent-orchestrator[anthropic]
+```
+
 To use the AnthropicClassifier, you need to create an instance with your Anthropic API key and pass it to the Multi-Agent Orchestrator:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/classifiers/built-in/openai-classifier.mdx
+++ b/docs/src/content/docs/classifiers/built-in/openai-classifier.mdx
@@ -16,6 +16,12 @@ The OpenAI Classifier extends the abstract `Classifier` class and uses the OpenA
 
 ## Basic Usage
 
+⚠️ To use OpenAI Classifier, make sure you have installed the multi-agent-orchestrator with openai feature (see [python installation](/multi-agent-orchestrator/general/quickstart#-get-started))
+
+```bash
+pip install multi-agent-orchestrator[openai]
+```
+
 To use the OpenAIClassifier, you need to create an instance with your OpenAI API key and pass it to the Multi-Agent Orchestrator:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/classifiers/overview.mdx
+++ b/docs/src/content/docs/classifiers/overview.mdx
@@ -11,6 +11,9 @@ The Classifier is a crucial component of the Multi-Agent Orchestrator, responsib
 
 - **[Anthropic Classifier](/multi-agent-orchestrator/classifiers/built-in/anthropic-classifier)** uses Anthropic's AI models for intent classification. It provides an alternative option for users who prefer or have access to Anthropic's services.
 
+- **[OpenAI Classifier](/multi-agent-orchestrator/classifiers/built-in/openai-classifier)** uses OpenAI's AI models for intent classification. It provides an alternative option for users who prefer or have access to OpenAI's services.
+
+
 ### Process Flow
 
 Regardless of the classifier used, the general process remains the same:
@@ -23,11 +26,11 @@ Regardless of the classifier used, the general process remains the same:
 
 By default, if no agent is selected the orchestrator can be configured to:
 
-A. Use a default agent (a **[BedrockLLMAgent](/multi-agent-orchestrator/agents/built-in/bedrock-llm-agent)**)
+A. Use a default agent (a **[BedrockLLMAgent for example](/multi-agent-orchestrator/agents/built-in/bedrock-llm-agent)**)
 
 B. Return a message prompting the user for more information.
 
-This behavior can be customized using the `USE_DEFAULT_AGENT_IF_NONE_IDENTIFIED` and `NO_SELECTED_AGENT_MESSAGE` configuration options in the orchestrator. 
+This behavior can be customized using the `USE_DEFAULT_AGENT_IF_NONE_IDENTIFIED` and `NO_SELECTED_AGENT_MESSAGE` configuration options in the orchestrator.
 
 For a detailed explanation of these options and other orchestrator configurations, please refer to the [Orchestrator Overview](/multi-agent-orchestrator/orchestrator/overview#agent-selection-and-default-behavior) page.
 
@@ -105,13 +108,13 @@ You can test any Classifier directly using the `classify` method:
         user_input = "What are the symptoms of the flu?"
         user_id = "test_user"
         session_id = "test_session"
-        
+
         # Fetch chat history (this might vary depending on your implementation)
         chat_history = await orchestrator.storage.fetch_all_chats(user_id, session_id)
-        
+
         # Classify the input
         response = await orchestrator.classifier.classify(user_input, chat_history)
-        
+
         print('\n** RESPONSE ** \n')
         print(f" > Agent ID: {response.selected_agent.id if response.selected_agent else 'None'}")
         print(f" > Agent Name: {response.selected_agent.name if response.selected_agent else 'None'}")

--- a/docs/src/content/docs/general/quickstart.mdx
+++ b/docs/src/content/docs/general/quickstart.mdx
@@ -38,7 +38,7 @@ To help you kickstart with the Multi-Agent Orchestrator framework, we'll walk yo
 
 2. Authenticate with your AWS account
 
-This quickstart demonstrates the use of Amazon Bedrock for both classification and agent responses. 
+This quickstart demonstrates the use of Amazon Bedrock for both classification and agent responses.
 
 To authenticate with your AWS account, follow these steps:
 
@@ -61,8 +61,8 @@ By default, the framework is configured as follows:
 <br/>
 
 > **Important**
-> 
->   These are merely default settings and can be easily changed to suit your needs or preferences. 
+>
+>   These are merely default settings and can be easily changed to suit your needs or preferences.
 
 <br/>
 
@@ -91,7 +91,10 @@ Ensure you have [requested access](https://docs.aws.amazon.com/bedrock/latest/us
   </TabItem>
   <TabItem label="Python" icon="seti:python">
     ```bash
-    pip install multi-agent-orchestrator
+    pip install multi-agent-orchestrator # for core dependencies
+    pip install multi-agent-orchestrator[anthropic] # for Anthropic classifier and agent
+    pip install multi-agent-orchestrator[openai] # for OpenAI classifier and agent
+    pip install multi-agent-orchestrator[all] # for all packages including Anthropic and OpenAI
     ```
   </TabItem>
 </Tabs>
@@ -165,7 +168,7 @@ Ensure you have [requested access](https://docs.aws.amazon.com/bedrock/latest/us
         streaming: true
       })
     );
-    
+
     orchestrator.addAgent(
       new BedrockLLMAgent({
         name: "Health Agent",
@@ -227,7 +230,7 @@ Ensure you have [requested access](https://docs.aws.amazon.com/bedrock/latest/us
             console.error("Received unexpected chunk type:", typeof chunk);
           }
         }
-        console.log(); 
+        console.log();
       } catch (error) {
         console.error("An error occurred:", error);
         // Here you could also add more specific error handling if needed

--- a/docs/src/content/docs/orchestrator/overview.mdx
+++ b/docs/src/content/docs/orchestrator/overview.mdx
@@ -49,6 +49,7 @@ The Orchestrator accepts an `OrchestratorConfig` object during initialization. A
    - `GENERAL_ROUTING_ERROR_MSG_MESSAGE`: Custom message for general routing errors.
 3. `logger`: Custom logger instance. If not provided, a default logger will be used.
 4. `classifier`: Custom classifier instance. If not provided, a `BedrockClassifier` will be used.
+5. `default_agent`: A default agent when the classifier could not determine the most suitable agent.
 
 ### Example with all options
 
@@ -107,7 +108,12 @@ Here's an example that demonstrates how to initialize the Orchestrator with all 
       ),
       storage=DynamoDBChatStorage(),
       classifier=CustomClassifier(),
-      logger=CustomLogger()
+      logger=CustomLogger(),
+      default_agent=BedrockLLMAgent(BedrockLLMAgentOptions(
+        name="Default Agent",
+        streaming=False,
+        description="This is the default agent that handles general queries and tasks.",
+      ))
     )
     ```
   </TabItem>

--- a/python/README.md
+++ b/python/README.md
@@ -72,7 +72,7 @@ Check out our [documentation](https://awslabs.github.io/multi-agent-orchestrator
 
 
 
-### Installation
+### Core Installation
 
 ```bash
 # Optional: Set up a virtual environment
@@ -81,7 +81,7 @@ source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 pip install multi-agent-orchestrator
 ```
 
-### Usage
+#### Default Usage
 
 Here's an equivalent Python example demonstrating the use of the Multi-Agent Orchestrator with a Bedrock LLM Agent and a Lex Bot Agent:
 
@@ -175,6 +175,19 @@ This example showcases:
 3. The orchestrator's ability to route requests to the most appropriate agent based on the input.
 4. Handling of both streaming and non-streaming responses from different types of agents.
 
+
+### Working with Anthropic or OpenAI
+If you want to use Anthropic or OpenAI for classifier and/or agents, make sure to install the multi-agent-orchestrator with the relevant extra feature.
+```bash
+pip install multi-agent-orchestrator[anthropic]
+pip install multi-agent-orchestrator[openai]
+```
+
+### Full package installation
+For a complete installation (including Anthropic and OpenAi):
+```bash
+pip install multi-agent-orchestrator[all]
+```
 
 ## 🤝 Contributing
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -21,6 +21,13 @@ packages = find:
 python_requires = >=3.11
 install_requires =
     boto3==1.34.151
+
+[options.extras_require]
+anthropic =
+    anthropic==0.32.0
+openai =
+    openai==1.55.0
+all =
     anthropic==0.32.0
     openai==1.55.0
 

--- a/python/src/multi_agent_orchestrator/agents/__init__.py
+++ b/python/src/multi_agent_orchestrator/agents/__init__.py
@@ -9,7 +9,13 @@ from .amazon_bedrock_agent import AmazonBedrockAgent, AmazonBedrockAgentOptions
 from .comprehend_filter_agent import ComprehendFilterAgent, ComprehendFilterAgentOptions
 from .chain_agent import ChainAgent, ChainAgentOptions
 from .bedrock_translator_agent import BedrockTranslatorAgent, BedrockTranslatorAgentOptions
-from .anthropic_agent import AnthropicAgent, AnthropicAgentOptions
+
+try:
+    from .anthropic_agent import AnthropicAgent, AnthropicAgentOptions
+    _ANTHROPIC_AVAILABLE = True
+except ImportError:
+    _ANTHROPIC_AVAILABLE = False
+
 
 __all__ = [
     'Agent',
@@ -24,13 +30,17 @@ __all__ = [
     'LexBotAgent',
     'LexBotAgentOptions',
     'AmazonBedrockAgent',
-    'AmazonBedrockAgentOptions'
+    'AmazonBedrockAgentOptions',
     'ComprehendFilterAgent',
     'ComprehendFilterAgentOptions',
     'BedrockTranslatorAgent',
     'BedrockTranslatorAgentOptions',
     'ChainAgent',
     'ChainAgentOptions',
-    'AnthropicAgent',
-    'AnthropicAgentOptions'
 ]
+
+if _ANTHROPIC_AVAILABLE:
+    __all__.extend([
+        'AnthropicAgent',
+        'AnthropicAgentOptions'
+    ])

--- a/python/src/multi_agent_orchestrator/classifiers/__init__.py
+++ b/python/src/multi_agent_orchestrator/classifiers/__init__.py
@@ -1,20 +1,38 @@
 """
 Code for Classifier.
 """
-
-
 from .classifier import Classifier, ClassifierResult
-from .anthropic_classifier import AnthropicClassifier, AnthropicClassifierOptions
 from .bedrock_classifier import BedrockClassifier, BedrockClassifierOptions
-from .openai_classifier import OpenAIClassifier, OpenAIClassifierOptions
+
+try:
+    from .anthropic_classifier import AnthropicClassifier, AnthropicClassifierOptions
+    _ANTHROPIC_AVAILABLE = True
+except Exception as e:
+    _ANTHROPIC_AVAILABLE = False
+
+try:
+    from .openai_classifier import OpenAIClassifier, OpenAIClassifierOptions
+    _OPENAI_AVAILABLE = True
+except Exception as e:
+    _OPENAI_AVAILABLE = False
+
+
 
 __all__ = [
-    "AnthropicClassifier",
-    "AnthropicClassifierOptions",
-    "BedrockClassifier",
-    "BedrockClassifierOptions",
     "Classifier",
     "ClassifierResult",
-    "OpenAIClassifier",
-    "OpenAIClassifierOptions",
+    "BedrockClassifier",
+    "BedrockClassifierOptions"
 ]
+
+if _ANTHROPIC_AVAILABLE:
+    __all__.extend([
+        "AnthropicClassifier",
+        "AnthropicClassifierOptions"
+    ])
+
+if _OPENAI_AVAILABLE:
+    __all__.extend([
+        "OpenAIClassifier",
+        "OpenAIClassifierOptions"
+    ])

--- a/python/src/multi_agent_orchestrator/classifiers/classifier.py
+++ b/python/src/multi_agent_orchestrator/classifiers/classifier.py
@@ -3,7 +3,7 @@ import re
 from typing import Dict, List, Optional
 from dataclasses import dataclass
 from multi_agent_orchestrator.types import ConversationMessage, AgentTypes, TemplateVariables
-from multi_agent_orchestrator.agents import Agent, BedrockLLMAgent, BedrockLLMAgentOptions
+from multi_agent_orchestrator.agents import Agent
 
 
 @dataclass
@@ -13,14 +13,6 @@ class ClassifierResult:
 
 class Classifier(ABC):
     def __init__(self):
-        self.default_agent = BedrockLLMAgent(
-            options=BedrockLLMAgentOptions(
-            name=AgentTypes.DEFAULT.value,
-            streaming=True,
-            description="A knowledgeable generalist capable of addressing a wide range of topics.\
-            This agent should be selected if no other specialized agent is a better fit."
-        ))
-
         self.agent_descriptions = ""
         self.history = ""
         self.custom_variables: TemplateVariables = {}

--- a/python/src/multi_agent_orchestrator/orchestrator.py
+++ b/python/src/multi_agent_orchestrator/orchestrator.py
@@ -9,9 +9,7 @@ from multi_agent_orchestrator.classifiers import (Classifier,
                              BedrockClassifierOptions)
 from multi_agent_orchestrator.agents import (Agent,
                         AgentResponse,
-                        AgentProcessingResult,
-                        BedrockLLMAgent,
-                        BedrockLLMAgentOptions)
+                        AgentProcessingResult)
 from multi_agent_orchestrator.storage import ChatStorage, InMemoryChatStorage
 
 @dataclass
@@ -20,7 +18,8 @@ class MultiAgentOrchestrator:
                  options: Optional[OrchestratorConfig] = None,
                  storage: Optional[ChatStorage] = None,
                  classifier: Optional[Classifier] = None,
-                 logger: Optional[Logger] = None):
+                 logger: Optional[Logger] = None,
+                 default_agent: Optional[Agent] = None):
 
         DEFAULT_CONFIG=OrchestratorConfig()
 
@@ -44,12 +43,7 @@ class MultiAgentOrchestrator:
         self.storage = storage or InMemoryChatStorage()
         self.classifier: Classifier = classifier or BedrockClassifier(options=BedrockClassifierOptions())
         self.execution_times: Dict[str, float] = {}
-        self.default_agent: Agent = BedrockLLMAgent(
-            options=BedrockLLMAgentOptions(
-                name="DEFAULT",
-                streaming=True,
-                description="A knowledgeable generalist capable of addressing a wide range of topics.",
-            ))
+        self.default_agent: Agent = default_agent
 
 
     def add_agent(self, agent: Agent):
@@ -135,7 +129,7 @@ class MultiAgentOrchestrator:
             )
 
         if not classifier_result.selected_agent:
-            if self.config.USE_DEFAULT_AGENT_IF_NONE_IDENTIFIED:
+            if self.config.USE_DEFAULT_AGENT_IF_NONE_IDENTIFIED and self.default_agent:
                 classifier_result = self.get_fallback_result()
                 self.logger.info("Using default agent as no agent was selected")
             else:

--- a/python/src/tests/classifiers/test_classifier.py
+++ b/python/src/tests/classifiers/test_classifier.py
@@ -1,0 +1,141 @@
+import unittest
+from unittest.mock import AsyncMock, patch, MagicMock
+from multi_agent_orchestrator.types import ConversationMessage, AgentTypes
+from multi_agent_orchestrator.agents import Agent
+from multi_agent_orchestrator.classifiers import Classifier, ClassifierResult
+import re
+from typing import List, Dict
+import pytest
+import asyncio
+
+class MockAgent(Agent):
+    def __init__(self, agent_id, description):
+        self.id = agent_id
+        self.description = description
+
+    async def process_request(
+            self,
+            input_text: str,
+            user_id: str,
+            session_id: str,
+            chat_history: List[ConversationMessage],
+            additional_params: Dict[str, str] = None
+        ):
+        return ConversationMessage(role="assistant", content="Mock response")
+
+class ConcreteClassifier(Classifier):
+    async def process_request(self, input_text, chat_history):
+        # For testing, we'll return a mock ClassifierResult
+        return ClassifierResult(
+            selected_agent=self.get_agent_by_id('agent-test'),
+            confidence=0.9
+        )
+
+class TestClassifier(unittest.TestCase):
+    def setUp(self):
+        self.classifier = ConcreteClassifier()
+
+        # Setup mock agents
+        self.agents = {
+            'agent-test': MockAgent('agent-test', 'Test agent description'),
+            'agent-tech': MockAgent('agent-tech', 'Technical support agent'),
+            'agent-billing': MockAgent('agent-billing', 'Billing support agent')
+        }
+        self.classifier.set_agents(self.agents)
+
+    def test_set_agents(self):
+        # Test that agents are correctly set and agent descriptions are generated
+        expected_descriptions = "\n\n".join([
+            "agent-test:Test agent description",
+            "agent-tech:Technical support agent",
+            "agent-billing:Billing support agent"
+        ])
+        self.assertEqual(self.classifier.agent_descriptions, expected_descriptions)
+        self.assertEqual(len(self.classifier.agents), 3)
+
+    def test_format_messages(self):
+        # Test message formatting
+        messages = [
+            ConversationMessage(role='user', content=[{'text': 'Hello'}]),
+            ConversationMessage(role='assistant', content=[{'text': 'Hi there'}])
+        ]
+
+        formatted_messages = self.classifier.format_messages(messages)
+        self.assertEqual(formatted_messages, "user: Hello\nassistant: Hi there")
+
+    def test_get_agent_by_id(self):
+        # Test getting agent by full and partial ID
+        agent = self.classifier.get_agent_by_id('agent-test')
+        self.assertIsNotNone(agent)
+        self.assertEqual(agent.id, 'agent-test')
+
+        # Test case insensitivity and partial matching
+        agent = self.classifier.get_agent_by_id('AGENT-TEST Something extra')
+        self.assertIsNotNone(agent)
+        self.assertEqual(agent.id, 'agent-test')
+
+    def test_get_agent_by_id_not_found(self):
+        # Test getting non-existent agent
+        agent = self.classifier.get_agent_by_id('non-existent-agent')
+        self.assertIsNone(agent)
+
+        self.assertIsNone(self.classifier.get_agent_by_id(None))
+
+
+    def test_replace_placeholders(self):
+        # Test placeholder replacement
+        template = "Hello {{NAME}}, welcome to {{COMPANY}}"
+        variables = {
+            "NAME": "John",
+            "COMPANY": "Acme Corp"
+        }
+
+        result = self.classifier.replace_placeholders(template, variables)
+        self.assertEqual(result, "Hello John, welcome to Acme Corp")
+
+    def test_replace_placeholders_with_list(self):
+        # Test placeholder replacement with list values
+        template = "Users: {{USERS}}"
+        variables = {
+            "USERS": ["Alice", "Bob", "Charlie"]
+        }
+
+        result = self.classifier.replace_placeholders(template, variables)
+        self.assertEqual(result, "Users: Alice\nBob\nCharlie")
+
+    def test_replace_placeholders_missing_key(self):
+        # Test placeholder replacement with missing key
+        template = "Hello {{NAME}}"
+        variables = {}
+
+        result = self.classifier.replace_placeholders(template, variables)
+        self.assertEqual(result, "Hello {{NAME}}")
+
+    @pytest.mark.asyncio
+    def test_classify(self):
+        # Use asyncio.run to properly await the async method
+        result = asyncio.run(self._async_test_classify())
+
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.selected_agent)
+        self.assertEqual(result.confidence, 0.9)
+        self.assertEqual(result.selected_agent.id, 'agent-test')
+
+    async def _async_test_classify(self):
+        # Separate async method to actually perform the test
+        chat_history = [
+            ConversationMessage(role='user', content=[{'text': 'Initial query'}])
+        ]
+
+        return await self.classifier.classify('Test input', chat_history)
+
+    def test_update_system_prompt(self):
+        # Test system prompt update with custom variables
+        custom_vars = {
+            "EXTRA_INFO": "Additional context"
+        }
+        template = self.classifier.prompt_template = '\n {{EXTRA_INFO}}'
+        self.classifier.set_system_prompt(template=template, variables=custom_vars)
+
+        # Check that custom variables are included in system prompt
+        self.assertIn("Additional context", self.classifier.system_prompt)

--- a/python/src/tests/storage/test_in_memory_chat_storage.py
+++ b/python/src/tests/storage/test_in_memory_chat_storage.py
@@ -77,6 +77,23 @@ async def test_fetch_all_chats(storage):
     assert result[1].content == "Hello Agent 2"
 
 @pytest.mark.asyncio
+async def test_fetch_all_chats(storage):
+    user_id = "user1"
+    session_id = "session1"
+    agent1_id = "agent1"
+    agent2_id = "agent2"
+    message1 = ConversationMessage(role="user", content=[{'text':"Hello"}])
+    message2 = ConversationMessage(role="assistant", content=[{'text':"Hello Agent 2"}])
+
+    await storage.save_chat_message(user_id, session_id, agent1_id, message1)
+    await storage.save_chat_message(user_id, session_id, agent2_id, message2)
+
+    result = await storage.fetch_all_chats(user_id, session_id)
+    assert len(result) == 2
+    assert result[0].content == [{'text':"Hello"}]
+    assert result[1].content == [{'text':"[agent2] Hello Agent 2"}]
+
+@pytest.mark.asyncio
 async def test_trim_conversation(storage):
     user_id = "user1"
     session_id = "session1"

--- a/typescript/src/classifiers/classifier.ts
+++ b/typescript/src/classifiers/classifier.ts
@@ -1,11 +1,7 @@
 import {
-  AgentTypes,
   ConversationMessage,
   TemplateVariables,
 } from "../types";
-import {
-  BedrockLLMAgent
-} from "../agents/bedrockLLMAgent";
 
 import { Agent } from "../agents/agent";
 
@@ -19,9 +15,7 @@ export interface ClassifierResult {
 }
 
 /**
- * IntentClassifier class extends BedrockAgent to provide specialized functionality
- * for classifying user intents, selecting appropriate agents, and generating
- * structured response.
+ * Abstract base class for all classifiers
  */
 export abstract class Classifier {
 
@@ -32,24 +26,14 @@ export abstract class Classifier {
   protected promptTemplate: string;
   protected systemPrompt: string;
   protected customVariables: TemplateVariables;
-  protected defaultAgent: Agent;
 
 
 
   /**
-   * Constructs a new IntentClassifier instance.
+   * Constructs a new Classifier instance.
    * @param options - Configuration options for the agent, inherited from AgentOptions.
    */
   constructor() {
-
-
-    this.defaultAgent = new BedrockLLMAgent({
-      name: AgentTypes.DEFAULT,
-      streaming: true,
-      description:
-        "A knowledgeable generalist capable of addressing a wide range of topics. This agent should be selected if no other specialized agent is a better fit.",
-    });
-
 
     this.agentDescriptions = "";
     this.history = "";

--- a/typescript/src/orchestrator.ts
+++ b/typescript/src/orchestrator.ts
@@ -1,10 +1,6 @@
 import { AgentOverlapAnalyzer } from "./agentOverlapAnalyzer";
-import {
-  AgentTypes,
-} from "./types/index";
 import { Agent, AgentResponse } from "./agents/agent";
 import { ClassifierResult } from './classifiers/classifier';
-import { BedrockLLMAgent } from "./agents/bedrockLLMAgent";
 import { ChatStorage } from "./storage/chatStorage";
 import { InMemoryChatStorage } from "./storage/memoryChatStorage";
 import { AccumulatorTransform } from "./utils/helpers";
@@ -155,6 +151,7 @@ export interface OrchestratorOptions {
   config?: Partial<OrchestratorConfig>;
   logger?: any;
   classifier?: Classifier;
+  defaultAgent?: Agent;
 }
 
 export interface RequestMetadata {
@@ -231,12 +228,7 @@ export class MultiAgentOrchestrator {
     this.agents = {};
     this.classifier = options.classifier || new BedrockClassifier();
 
-    this.defaultAgent = new BedrockLLMAgent({
-      name: AgentTypes.DEFAULT,
-      streaming: true,
-      description:
-        "A knowledgeable generalist capable of addressing a wide range of topics. This agent should be selected if no other specialized agent is a better fit.",
-    });
+    this.defaultAgent = options.defaultAgent;
 
   }
 
@@ -370,7 +362,7 @@ export class MultiAgentOrchestrator {
     try {
       // Handle case where no agent was selected
       if (!classifierResult.selectedAgent) {
-        if (this.config.USE_DEFAULT_AGENT_IF_NONE_IDENTIFIED) {
+        if (this.config.USE_DEFAULT_AGENT_IF_NONE_IDENTIFIED && this.defaultAgent) {
           classifierResult = this.getFallbackResult();
           this.logger.info("Using default agent as no agent was selected");
         } else {

--- a/typescript/tests/classifiers/Classifier.test.ts
+++ b/typescript/tests/classifiers/Classifier.test.ts
@@ -39,7 +39,7 @@ class MockClassifier extends Classifier {
       };
     }
     return {
-      selectedAgent: this.defaultAgent,
+      selectedAgent: null,
       confidence: 0.5
     };
   }
@@ -156,7 +156,7 @@ describe('Classifier', () => {
 
     test('should return default agent for non-specific input', async () => {
       const result = await classifier.classify('General question', []);
-      expect(result.selectedAgent).toBe(classifier['defaultAgent']);
+      expect(result.selectedAgent).toBe(null);
       expect(result.confidence).toBe(0.5);
     });
   });


### PR DESCRIPTION
## Remove AWS Credentials dependency (AWS Bedrock default agent)
See #106 

## Python feature installation
The multi-agent orchestrator can now be installed with the required python package dependencies.
Before, anthropic sdk was installed even if Anthropic classifier or Agent were used.
Now, the core package are installed when using: 
```bash
pip install multi-agent-orchestrator
```

To use Anthropic Classifier or Agent:
you must install the MAO with anthropic feature:
```bash
pip install multi-agent-orchestrator[anthropic]
```

same applies for OpenAI classifier:
```bash
pip install multi-agent-orchestrator[openai]
```