### PR TITLE
Toolchoice exception

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2907,9 +2907,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",

--- a/docs/src/content/docs/agents/built-in/amazon-bedrock-agent.mdx
+++ b/docs/src/content/docs/agents/built-in/amazon-bedrock-agent.mdx
@@ -40,12 +40,14 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 In this basic example, we provide the four required parameters: `name`, `description`, `agent_id`, and `agent_alias_id`.
 
-### Parameter Explanations
+### Option Explanations
 
 - `name`: (Required) Identifies the agent within your system.
 - `description`: (Required) Describes the agent's purpose or capabilities.
 - `agent_id`: (Required) The ID of the Amazon Bedrock agent you want to use.
 - `agent_alias_id`: (Required) The alias ID of the Amazon Bedrock agent.
+- `enableTrace`: If you set enableTrace to `true` in the request, you can trace the agent’s steps and reasoning process that led it to the response.
+- `streaming`: Specifies whether to enable streaming for the final response. This is set to false by default `False`
 
 ## Adding the Agent to the Orchestrator
 

--- a/python/src/multi_agent_orchestrator/agents/amazon_bedrock_agent.py
+++ b/python/src/multi_agent_orchestrator/agents/amazon_bedrock_agent.py
@@ -1,5 +1,11 @@
-"""This module implements an Amazon Bedrock agent that interacts with a runtime client.
 """
+Amazon Bedrock Agent Integration Module
+
+This module provides a robust implementation for interacting with Amazon Bedrock agents,
+offering a flexible and extensible way to process conversational interactions using
+AWS Bedrock's agent runtime capabilities.
+"""
+
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
 import os
@@ -12,33 +18,69 @@ from multi_agent_orchestrator.utils import Logger
 
 @dataclass
 class AmazonBedrockAgentOptions(AgentOptions):
-    """Options for Amazon Bedrock Agent."""
+    """
+    Configuration options for Amazon Bedrock Agent initialization.
+
+    Provides flexible configuration for Bedrock agent runtime:
+    - agent_id: Unique identifier for the Bedrock agent
+    - agent_alias_id: Specific alias for the agent
+    - client: Optional custom boto3 client (allows dependency injection)
+    - streaming: Flag to enable streaming response mode (on final response)
+    - enableTrace: Flag to enable detailed event tracing
+    """
     agent_id: str = None
     agent_alias_id: str = None
     client: Optional[Any] = None
+    streaming: Optional[bool] = False
+    enableTrace: Optional[bool] = False
 
 
 class AmazonBedrockAgent(Agent):
     """
-    Represents an Amazon Bedrock agent that interacts with a runtime client.
-    Extends base Agent class and implements specific methods for Amazon Bedrock.
+    Specialized agent for interacting with Amazon Bedrock's intelligent agent runtime.
+
+    This class extends the base Agent class to provide:
+    - Direct integration with AWS Bedrock agent runtime
+    - Configurable response handling (streaming/non-streaming)
+    - Comprehensive error management
+    - Flexible session and conversation state management
     """
 
     def __init__(self, options: AmazonBedrockAgentOptions):
         """
-        Constructs an instance of AmazonBedrockAgent with the specified options.
-        Initializes the agent ID, agent alias ID, and creates a new Bedrock agent runtime client.
+        Initialize the Bedrock agent with comprehensive configuration.
 
-        :param options: Options to configure the Amazon Bedrock agent.
+        Handles client creation, either using a provided client or
+        automatically creating one based on AWS configuration.
+
+        :param options: Detailed configuration for agent initialization
         """
         super().__init__(options)
+
+        # Store core agent identifiers
         self.agent_id = options.agent_id
         self.agent_alias_id = options.agent_alias_id
+
+        # Set up Bedrock runtime client
         if options.client:
+            # Use provided client (useful for testing or custom configurations)
             self.client = options.client
         else:
+            # Create default client using AWS region from options or environment
             self.client = boto3.client('bedrock-agent-runtime',
                                     region_name=options.region or os.environ.get('AWS_REGION'))
+
+        # Configure response handling modes
+        self.streaming = options.streaming
+        self.enableTrace = options.enableTrace
+
+    def is_streaming_enabled(self) -> bool:
+        """
+        Check if streaming mode is active for response processing.
+
+        :return: Boolean indicating streaming status
+        """
+        return self.streaming is True
 
     async def process_request(
         self,
@@ -49,43 +91,70 @@ class AmazonBedrockAgent(Agent):
         additional_params: Optional[Dict[str, str]] = None
     ) -> ConversationMessage:
         """
-        Processes a user request by sending it to the Amazon Bedrock agent for processing.
+        Process a user request through the Bedrock agent runtime.
 
-        :param input_text: The user input as a string.
-        :param user_id: The ID of the user sending the request.
-        :param session_id: The ID of the session associated with the conversation.
-        :param chat_history: A list of ConversationMessage objects representing
-        the conversation history.
-        :param additional_params: Optional additional parameters as key-value pairs.
-        :return: A ConversationMessage object containing the agent's response.
+        Handles the entire interaction lifecycle:
+        - Manages session state
+        - Invokes agent with configured parameters
+        - Processes streaming or non-streaming responses
+        - Handles potential errors
+
+        :param input_text: User's input message
+        :param user_id: Identifier for the user
+        :param session_id: Unique conversation session identifier
+        :param chat_history: Previous conversation messages
+        :param additional_params: Optional supplementary parameters
+        :return: Agent's response as a conversation message
         """
-
+        # Initialize session state, defaulting to empty if not provided
         session_state = {}
         if (additional_params and 'sessionState' in additional_params):
             session_state = additional_params['sessionState']
+
         try:
+            # Configure streaming behavior
+            streamingConfigurations = {
+                'streamFinalResponse': self.streaming
+            }
+
+            # Invoke Bedrock agent with comprehensive configuration
             response = self.client.invoke_agent(
                 agentId=self.agent_id,
                 agentAliasId=self.agent_alias_id,
                 sessionId=session_id,
                 inputText=input_text,
-                sessionState=session_state
+                enableTrace=self.enableTrace,
+                sessionState=session_state,
+                streamingConfigurations=streamingConfigurations if self.streaming else {}
             )
 
+            # Process response, handling both streaming and non-streaming modes
             completion = ""
             for event in response['completion']:
                 if 'chunk' in event:
+                    # Process streaming chunk
                     chunk = event['chunk']
                     decoded_response = chunk['bytes'].decode('utf-8')
-                    completion += decoded_response
-                else:
-                    Logger.warn("Received a chunk event with no chunk data")
 
+                    # Trigger callback for each token (useful for real-time updates)
+                    self.callbacks.on_llm_new_token(decoded_response)
+                    completion += decoded_response
+
+                elif 'trace' in event:
+                    # Log trace events if tracing is enabled
+                    Logger.info(f"Received event: {event}") if self.enableTrace else None
+
+                else:
+                    # Ignore unrecognized event types
+                    pass
+
+            # Construct and return the conversation message
             return ConversationMessage(
                 role=ParticipantRole.ASSISTANT.value,
                 content=[{"text": completion}]
             )
 
         except (BotoCoreError, ClientError) as error:
+            # Comprehensive error logging and propagation
             Logger.error(f"Error processing request: {str(error)}")
             raise error

--- a/python/src/multi_agent_orchestrator/classifiers/bedrock_classifier.py
+++ b/python/src/multi_agent_orchestrator/classifiers/bedrock_classifier.py
@@ -76,18 +76,24 @@ class BedrockClassifier(Classifier):
             content=[{"text": input_text}]
         )
 
+        toolConfig = {
+            "tools": self.tools,
+        }
+
+        # ToolChoice is only supported by Anthropic Claude 3 models and by Mistral AI Mistral Large.
+        # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
+        if "anthropic" in self.model_id or 'mistral-large' in self.model_id:
+            toolConfig['toolChoice'] = {
+                "tool": {
+                    "name": "analyzePrompt",
+                },
+            }
+
         converse_cmd = {
             "modelId": self.model_id,
             "messages": [user_message.__dict__],
             "system": [{"text": self.system_prompt}],
-            "toolConfig": {
-                "tools": self.tools,
-                "toolChoice": {
-                    "tool": {
-                        "name": "analyzePrompt",
-                    },
-                },
-            },
+            "toolConfig": toolConfig,
             "inferenceConfig": {
                 "maxTokens": self.inference_config['maxTokens'],
                 "temperature": self.inference_config['temperature'],

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -4746,9 +4746,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",


### PR DESCRIPTION
Only use toolChoice, in the classifier for Anthropic and Mistral AI Large models.

as per the documentation: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html