### PR TITLE
fixing agent key to accept numbers - issue #80

### DIFF
--- a/python/src/multi_agent_orchestrator/agents/agent.py
+++ b/python/src/multi_agent_orchestrator/agents/agent.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from multi_agent_orchestrator.types import ConversationMessage
 from multi_agent_orchestrator.utils import Logger
 
+
 @dataclass
 class AgentProcessingResult:
     user_input: str
@@ -12,6 +13,7 @@ class AgentProcessingResult:
     user_id: str
     session_id: str
     additional_params: Dict[str, any] = field(default_factory=dict)
+
 
 @dataclass
 class AgentResponse:
@@ -24,6 +26,7 @@ class AgentCallbacks:
     def on_llm_new_token(self, token: str) -> None:
         # Default implementation
         pass
+
 
 @dataclass
 class AgentOptions:
@@ -44,8 +47,14 @@ class Agent(ABC):
         self.id = self.generate_key_from_name(options.name)
         self.description = options.description
         self.save_chat = options.save_chat
-        self.callbacks = options.callbacks if options.callbacks is not None else AgentCallbacks()
-        self.LOG_AGENT_DEBUG_TRACE = options.LOG_AGENT_DEBUG_TRACE if options.LOG_AGENT_DEBUG_TRACE is not None else False
+        self.callbacks = (
+            options.callbacks if options.callbacks is not None else AgentCallbacks()
+        )
+        self.LOG_AGENT_DEBUG_TRACE = (
+            options.LOG_AGENT_DEBUG_TRACE
+            if options.LOG_AGENT_DEBUG_TRACE is not None
+            else False
+        )
 
     def is_streaming_enabled(self) -> bool:
         return False
@@ -53,9 +62,10 @@ class Agent(ABC):
     @staticmethod
     def generate_key_from_name(name: str) -> str:
         import re
+
         # Remove special characters and replace spaces with hyphens
-        key = re.sub(r'[^a-zA-Z\s-]', '', name)
-        key = re.sub(r'\s+', '-', key)
+        key = re.sub(r"[^a-zA-Z0-9\s-]", "", name)
+        key = re.sub(r"\s+", "-", key)
         return key.lower()
 
     @abstractmethod
@@ -65,7 +75,7 @@ class Agent(ABC):
         user_id: str,
         session_id: str,
         chat_history: List[ConversationMessage],
-        additional_params: Optional[Dict[str, str]] = None
+        additional_params: Optional[Dict[str, str]] = None,
     ) -> Union[ConversationMessage, AsyncIterable[any]]:
         pass
 

--- a/typescript/src/agents/agent.ts
+++ b/typescript/src/agents/agent.ts
@@ -115,7 +115,7 @@ export abstract class Agent {
   private generateKeyFromName(name: string): string {
     // Remove special characters and replace spaces with hyphens
     const key = name
-      .replace(/[^a-zA-Z\s-]/g, "")
+      .replace(/[^a-zA-Z0-9\s-]/g, "")
       .replace(/\s+/g, "-")
       .toLowerCase();
     return key;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**
 #80

## Summary

Changing  agent id  regex to accept digits  all changes in agent file only in both python and typescript
### Changes
**Python**
Prev : ` key = re.sub(r"[^a-zA-Z\s-]", "", name)`
New : `key = re.sub(r"[^a-zA-Z0-9\s-]", "", name)`

 **Typescript :**  

Prev : ` .replace(/[^a-zA-Z\s-]/g, ""))`
New : `.replace(/[^a-zA-Z0-9\s-]/g, ""))`


> Please provide a summary of what's being changed

Agent id now can have digits in it .
### User experience

> Please share what the user experience looks like before and after this change

Previously, if the user had an agent ID containing digits, the numbers would be removed. Now, the numbers will be retained.

Examples before  here if user changed the digit it will return agent already exists 
```
Agent Name: Image2-You
Agent ID: image-you

Agent Name: Image4-You
Agent ID: image-you
```

Example after : 
```
 Agent Name: Image2-You
Agent ID: image2-you

Agent Name: Image4-You
Agent ID: image4-you
```
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ 👍 ] I have performed a self-review of this change
* [👍  ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
