### PR TITLE
fix[typos] - use `Any` from typing instead of `any` (which is a function)

### DIFF
--- a/python/src/multi_agent_orchestrator/agents/agent.py
+++ b/python/src/multi_agent_orchestrator/agents/agent.py
@@ -12,7 +12,7 @@ class AgentProcessingResult:
     agent_name: str
     user_id: str
     session_id: str
-    additional_params: Dict[str, any] = field(default_factory=dict)
+    additional_params: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -76,7 +76,7 @@ class Agent(ABC):
         session_id: str,
         chat_history: List[ConversationMessage],
         additional_params: Optional[Dict[str, str]] = None,
-    ) -> Union[ConversationMessage, AsyncIterable[any]]:
+    ) -> Union[ConversationMessage, AsyncIterable[Any]]:
         pass
 
     def log_debug(self, class_name, message, data=None):

--- a/python/src/multi_agent_orchestrator/agents/chain_agent.py
+++ b/python/src/multi_agent_orchestrator/agents/chain_agent.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union, AsyncIterable, Optional
+from typing import List, Dict, Union, AsyncIterable, Optional, Any
 from multi_agent_orchestrator.types import ConversationMessage, ParticipantRole
 from multi_agent_orchestrator.utils.logger import Logger
 from .agent import Agent, AgentOptions
@@ -24,9 +24,9 @@ class ChainAgent(Agent):
         session_id: str,
         chat_history: List[ConversationMessage],
         additional_params: Optional[Dict[str, str]] = None
-    ) -> Union[ConversationMessage, AsyncIterable[any]]:
+    ) -> Union[ConversationMessage, AsyncIterable[Any]]:
         current_input = input_text
-        final_response: Union[ConversationMessage, AsyncIterable[any]]
+        final_response: Union[ConversationMessage, AsyncIterable[Any]]
 
         for i, agent in enumerate(self.agents):
             is_last_agent = i == len(self.agents) - 1
@@ -67,11 +67,11 @@ class ChainAgent(Agent):
         return final_response
 
     @staticmethod
-    def is_async_iterable(obj: any) -> bool:
+    def is_async_iterable(obj: Any) -> bool:
         return hasattr(obj, '__aiter__')
 
     @staticmethod
-    def is_conversation_message(response: any) -> bool:
+    def is_conversation_message(response: Any) -> bool:
         return (
             isinstance(response, ConversationMessage) and
             hasattr(response, 'role') and

--- a/python/src/multi_agent_orchestrator/retrievers/retriever.py
+++ b/python/src/multi_agent_orchestrator/retrievers/retriever.py
@@ -1,3 +1,4 @@
+from typing import Any
 from abc import ABC, abstractmethod
 
 class Retriever(ABC):
@@ -16,7 +17,7 @@ class Retriever(ABC):
         self._options = options
 
     @abstractmethod
-    async def retrieve(self, text: str) -> any:
+    async def retrieve(self, text: str) -> Any:
         """
         Abstract method for retrieving information based on input text.
         This method must be implemented by all concrete subclasses.
@@ -25,12 +26,12 @@ class Retriever(ABC):
             text (str): The input text to base the retrieval on.
 
         Returns:
-            any: The retrieved information.
+            Any: The retrieved information.
         """
         pass
 
     @abstractmethod
-    async def retrieve_and_combine_results(self, text: str) -> any:
+    async def retrieve_and_combine_results(self, text: str) -> Any:
         """
         Abstract method for retrieving information and combining results.
         This method must be implemented by all concrete subclasses.
@@ -40,12 +41,12 @@ class Retriever(ABC):
             text (str): The input text to base the retrieval on.
 
         Returns:
-            any: The combined retrieval results.
+            Any: The combined retrieval results.
         """
         pass
 
     @abstractmethod
-    async def retrieve_and_generate(self, text: str) -> any:
+    async def retrieve_and_generate(self, text: str) -> Any:
         """
         Abstract method for retrieving information and generating something based on the results.
         This method must be implemented by all concrete subclasses.
@@ -55,6 +56,6 @@ class Retriever(ABC):
             text (str): The input text to base the retrieval on.
 
         Returns:
-            any: The generated information based on retrieval results.
+            Any: The generated information based on retrieval results.
         """
         pass


### PR DESCRIPTION
## Summary

`Any` is a type whereas `any` is a function. In some places, `any` is being used instead of `Any`

### Changes

Replace `any` with `Any` and import `Any` if not imported.

### User experience

No impact on runtime or user experience because types are optional 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have performed a self-review of this change
* [ x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change? No</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
