### PR TITLE
Export SqlChatStorage for typescript

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -22,6 +22,7 @@ export { AmazonKnowledgeBasesRetriever, AmazonKnowledgeBasesRetrieverOptions } f
 export { ChatStorage } from './storage/chatStorage';
 export { InMemoryChatStorage } from './storage/memoryChatStorage';
 export { DynamoDbChatStorage } from './storage/dynamoDbChatStorage';
+export { SqlChatStorage } from './storage/sqlChatStorage';
 
 export { Logger } from './utils/logger';
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

## Summary

Export `SqlChatStorage` for typescript

### Changes

This is a followup from https://github.com/awslabs/multi-agent-orchestrator/pull/111. It looks like SqlChatStorage was never exported at the global module level, so consumers cannot import it. 

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
