### PR TITLE
Fix: Implement `save_chat_messages` in `SQLChatStorage` and Improve Reliability

### DIFF
--- a/docs/src/content/docs/storage/sql.mdx
+++ b/docs/src/content/docs/storage/sql.mdx
@@ -71,14 +71,32 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
     # For local SQLite database
     local_storage = SqlChatStorage('file:local.db')
+    await local_storage.initialize()  # Must be called before use
 
     # For remote Turso database
     remote_storage = SqlChatStorage(
-      url='libsql://your-database-url.turso.io',
-      auth_token='your-auth-token'
+        url='libsql://your-database-url.turso.io',
+        auth_token='your-auth-token'
     )
+    await remote_storage.initialize()
 
+    # Create orchestrator with storage
     orchestrator = MultiAgentOrchestrator(storage=local_storage)  # or remote_storage
+
+    # Example usage
+    messages = await local_storage.save_chat_message(
+        user_id="user123",
+        session_id="session456",
+        agent_id="agent789",
+        new_message=ConversationMessage(
+            role="user",
+            content=[{"text": "Hello!"}]
+        )
+    )
+    # messages will contain the updated conversation history
+
+    # Don't forget to close connections when done
+    await local_storage.close()
     ```
   </TabItem>
 </Tabs>
@@ -87,21 +105,46 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Local DB
 For local development, simply provide a file URL:
-```typescript
-const storage = new SqlChatStorage('file:local.db');
-```
+### Local DB
+For local development, simply provide a file URL:
+<Tabs syncKey="local-storage">
+  <TabItem label="TypeScript" icon="seti:typescript" color="blue">
+    ```typescript
+    const storage = new SqlChatStorage('file:local.db');
+    ```
+  </TabItem>
+  <TabItem label="Python" icon="seti:python" color="blue">
+    ```python
+    storage = SqlChatStorage('file:local.db')
+    await storage.initialize()  # Must be called before use
+    ```
+  </TabItem>
+</Tabs>
 
 ### Remote DB
 For production with Turso:
 1. Create a Turso database through their platform
 2. Obtain your database URL and authentication token
 3. Configure your storage:
-```typescript
-const storage = new SqlChatStorage(
-  'libsql://your-database-url.com',
-  'your-auth-token'
-);
-```
+<Tabs syncKey="remote-storage">
+  <TabItem label="TypeScript" icon="seti:typescript" color="blue">
+    ```typescript
+    const storage = new SqlChatStorage(
+      'libsql://your-database-url.turso.io',
+      'your-auth-token'
+    );
+    ```
+  </TabItem>
+  <TabItem label="Python" icon="seti:python" color="blue">
+    ```python
+    storage = SqlChatStorage(
+        url='libsql://your-database-url.turso.io',
+        auth_token='your-auth-token'
+    )
+    await storage.initialize()  # Required initialization
+    ```
+  </TabItem>
+</Tabs>
 
 ## Database Schema
 
@@ -131,14 +174,50 @@ ON conversations(user_id, session_id, agent_id);
 - Support for message history size limits
 - Automatic JSON serialization/deserialization of message content
 
-## Best Practices
+## Best Practices (Python)
 
-- Use a single instance of SqlChatStorage throughout your application
-- Regularly backup your database
-- Implement data cleanup strategies for old conversations
-- Monitor database size and performance
-- Keep your authentication tokens secure
-- Implement proper access controls at the application level
-- Close the database connections when done
+1. **Initialization**:
+   ```python
+   storage = SqlChatStorage('file:local.db')
+   await storage.initialize()  # Always call initialize after creation
+   ```
+
+2. **Error Handling**:
+   ```python
+   try:
+       messages = await storage.save_chat_message(...)
+   except Exception as e:
+       logger.error(f"Storage error: {e}")
+   ```
+
+3. **Resource Cleanup**:
+   ```python
+   try:
+       storage = SqlChatStorage('file:local.db')
+       await storage.initialize()
+       # ... use storage ...
+   finally:
+       await storage.close()  # Always close when done
+   ```
+
+4. **Message History Management**:
+   ```python
+   # Limit conversation history
+   messages = await storage.save_chat_message(
+       ...,
+       max_history_size=50  # Keep last 50 messages
+   )
+   ```
+
+5. **Batch Operations**:
+   ```python
+   # Save multiple messages efficiently
+   messages = await storage.save_chat_messages(
+       user_id="user123",
+       session_id="session456",
+       agent_id="agent789",
+       new_messages=[message1, message2, message3]
+   )
+   ```
 
 SQL storage provides a robust and flexible solution for managing conversation history in the Multi-Agent Orchestrator System. It offers a good balance between simplicity and features, making it suitable for both development and production environments.

--- a/python/src/multi_agent_orchestrator/storage/sql_chat_storage.py
+++ b/python/src/multi_agent_orchestrator/storage/sql_chat_storage.py
@@ -1,7 +1,7 @@
 from typing import List, Dict, Optional, Union
 import time
 import json
-from libsql_client import Client, create_client
+from libsql_client import create_client
 from multi_agent_orchestrator.storage import ChatStorage
 from multi_agent_orchestrator.types import ConversationMessage, ParticipantRole, TimestampedMessage
 from multi_agent_orchestrator.utils import Logger
@@ -25,13 +25,16 @@ class SqlChatStorage(ChatStorage):
             url=url,
             auth_token=auth_token
         )
-        self._initialize_database()
 
-    def _initialize_database(self) -> None:
+    async def initialize(self) -> None:
+        """Initialize the database asynchronously. Must be called after creating the instance."""
+        await self._initialize_database()
+
+    async def _initialize_database(self) -> None:
         """Create necessary tables and indexes if they don't exist."""
         try:
             # Create conversations table
-            self.client.execute("""
+            await self.client.execute("""
                 CREATE TABLE IF NOT EXISTS conversations (
                     user_id TEXT NOT NULL,
                     session_id TEXT NOT NULL,
@@ -45,7 +48,7 @@ class SqlChatStorage(ChatStorage):
             """)
 
             # Create index for faster queries
-            self.client.execute("""
+            await self.client.execute("""
                 CREATE INDEX IF NOT EXISTS idx_conversations_lookup 
                 ON conversations(user_id, session_id, agent_id)
             """)
@@ -58,7 +61,7 @@ class SqlChatStorage(ChatStorage):
         user_id: str,
         session_id: str,
         agent_id: str,
-        new_message: ConversationMessage,
+        new_message: Union[ConversationMessage, TimestampedMessage],
         max_history_size: Optional[int] = None
     ) -> List[ConversationMessage]:
         """Save a new chat message."""
@@ -70,54 +73,150 @@ class SqlChatStorage(ChatStorage):
                 Logger.debug(f"> Consecutive {new_message.role} message detected for agent {agent_id}. Not saving.")
                 return existing_conversation
 
+            # Convert to TimestampedMessage if needed
+            if isinstance(new_message, ConversationMessage):
+                new_message = TimestampedMessage(
+                    role=new_message.role,
+                    content=new_message.content
+                )
+
             # Get next message index
-            result = self.client.execute("""
+            result = await self.client.execute("""
                 SELECT COALESCE(MAX(message_index) + 1, 0) as next_index
                 FROM conversations
                 WHERE user_id = ? AND session_id = ? AND agent_id = ?
             """, [user_id, session_id, agent_id])
             
-            next_index = result.rows[0]['next_index']
-            timestamp = int(time.time() * 1000)
+            next_index = result[0]['next_index']
             content = json.dumps(new_message.content)
 
-            # Begin transaction
-            with self.client.transaction():
-                # Insert new message
-                self.client.execute("""
+            # Insert new message
+            await self.client.execute("""
+                INSERT INTO conversations (
+                    user_id, session_id, agent_id, message_index,
+                    role, content, timestamp
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, [
+                user_id, session_id, agent_id, next_index,
+                new_message.role, content, new_message.timestamp or int(time.time() * 1000)
+            ])
+
+            # Clean up old messages if max_history_size is set
+            if max_history_size is not None:
+                await self.client.execute("""
+                    DELETE FROM conversations
+                    WHERE user_id = ?
+                        AND session_id = ?
+                        AND agent_id = ?
+                        AND message_index <= (
+                            SELECT MAX(message_index) - ?
+                            FROM conversations
+                            WHERE user_id = ?
+                                AND session_id = ?
+                                AND agent_id = ?
+                        )
+                """, [
+                    user_id, session_id, agent_id,
+                    max_history_size,
+                    user_id, session_id, agent_id
+                ])
+
+            # Return updated conversation
+            return await self.fetch_chat(user_id, session_id, agent_id)
+
+        except Exception as error:
+            Logger.error(f"Error saving message: {str(error)}")
+            raise error
+
+    def _validate_message_content(self, content: Optional[List[Dict[str, str]]]) -> None:
+        """Validate message content before serialization."""
+        if content is None:
+            raise ValueError("Message content cannot be None")
+        if not isinstance(content, list):
+            raise ValueError("Message content must be a list")
+        if not all(isinstance(item, dict) for item in content):
+            raise ValueError("Message content must be a list of dictionaries")
+
+    async def save_chat_messages(
+        self,
+        user_id: str,
+        session_id: str,
+        agent_id: str,
+        new_messages: Union[List[ConversationMessage], List[TimestampedMessage]],
+        max_history_size: Optional[int] = None
+    ) -> List[ConversationMessage]:
+        """Save multiple chat messages in a single transaction."""
+        try:
+            if not new_messages:
+                return await self.fetch_chat(user_id, session_id, agent_id)
+
+            # Convert messages to TimestampedMessage if needed
+            timestamped_messages = []
+            base_timestamp = int(time.time() * 1000)
+            
+            for i, message in enumerate(new_messages):
+                if isinstance(message, ConversationMessage):
+                    timestamped_messages.append(TimestampedMessage(
+                        role=message.role,
+                        content=message.content,
+                        timestamp=base_timestamp + i
+                    ))
+                else:
+                    timestamped_messages.append(message)
+
+            # Get next message index
+            result = await self.client.execute("""
+                SELECT COALESCE(MAX(message_index) + 1, 0) as next_index
+                FROM conversations
+                WHERE user_id = ? AND session_id = ? AND agent_id = ?
+            """, [user_id, session_id, agent_id])
+            
+            next_index = result[0]['next_index']
+
+            # Validate and prepare all messages first to catch any errors
+            message_params = []
+            for i, message in enumerate(timestamped_messages):
+                self._validate_message_content(message.content)
+                content = json.dumps(message.content)
+                message_params.append([
+                    user_id, session_id, agent_id, next_index + i,
+                    message.role, content, message.timestamp or (base_timestamp + i)
+                ])
+
+            # Insert messages one by one
+            for params in message_params:
+                await self.client.execute("""
                     INSERT INTO conversations (
                         user_id, session_id, agent_id, message_index,
                         role, content, timestamp
                     ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """, params)
+
+            # Clean up old messages if max_history_size is set
+            if max_history_size is not None:
+                await self.client.execute("""
+                    DELETE FROM conversations
+                    WHERE user_id = ?
+                        AND session_id = ?
+                        AND agent_id = ?
+                        AND message_index <= (
+                            SELECT MAX(message_index) - ?
+                            FROM conversations
+                            WHERE user_id = ?
+                                AND session_id = ?
+                                AND agent_id = ?
+                        )
                 """, [
-                    user_id, session_id, agent_id, next_index,
-                    new_message.role, content, timestamp
+                    user_id, session_id, agent_id,
+                    max_history_size,
+                    user_id, session_id, agent_id
                 ])
 
-                # Clean up old messages if max_history_size is set
-                if max_history_size is not None:
-                    self.client.execute("""
-                        DELETE FROM conversations
-                        WHERE user_id = ?
-                            AND session_id = ?
-                            AND agent_id = ?
-                            AND message_index <= (
-                                SELECT MAX(message_index) - ?
-                                FROM conversations
-                                WHERE user_id = ?
-                                    AND session_id = ?
-                                    AND agent_id = ?
-                            )
-                    """, [
-                        user_id, session_id, agent_id,
-                        max_history_size,
-                        user_id, session_id, agent_id
-                    ])
-
             # Return updated conversation
-            return await self.fetch_chat(user_id, session_id, agent_id, max_history_size)
+            return await self.fetch_chat(user_id, session_id, agent_id)
+
         except Exception as error:
-            Logger.error(f"Error saving message: {str(error)}")
+            Logger.error(f"Error saving messages: {str(error)}")
             raise error
 
     async def fetch_chat(
@@ -134,17 +233,15 @@ class SqlChatStorage(ChatStorage):
                 FROM conversations
                 WHERE user_id = ? AND session_id = ? AND agent_id = ?
                 ORDER BY message_index {}
-            """.format('DESC LIMIT ?' if max_history_size else 'ASC')
+            """.format('DESC' if max_history_size else 'ASC')
 
             params = [user_id, session_id, agent_id]
-            if max_history_size:
-                params.append(max_history_size)
+            
+            result = await self.client.execute(query, params)
+            messages = list(result)  # Convert ResultSet to list
 
-            result = self.client.execute(query, params)
-            messages = result.rows
-
-            # If we used LIMIT, reverse to maintain chronological order
             if max_history_size:
+                messages = messages[:max_history_size]
                 messages.reverse()
 
             return [
@@ -164,7 +261,7 @@ class SqlChatStorage(ChatStorage):
     ) -> List[ConversationMessage]:
         """Fetch all chat messages for a user and session."""
         try:
-            result = self.client.execute("""
+            result = await self.client.execute("""
                 SELECT role, content, timestamp, agent_id
                 FROM conversations
                 WHERE user_id = ? AND session_id = ?
@@ -179,7 +276,7 @@ class SqlChatStorage(ChatStorage):
                         json.loads(msg['content']),
                         msg['agent_id']
                     )
-                ) for msg in result.rows
+                ) for msg in result
             ]
         except Exception as error:
             Logger.error(f"Error fetching all chats: {str(error)}")
@@ -197,6 +294,10 @@ class SqlChatStorage(ChatStorage):
             return [{'text': f"[{agent_id}] {text}"}]
         return content if isinstance(content, list) else [{'text': content}]
 
-    def close(self) -> None:
+    async def close(self) -> None:
         """Close the database connection."""
-        self.client.close()
+        try:
+            await self.client.close()
+        except Exception as error:
+            Logger.error(f"Error closing database connection: {str(error)}")
+            raise error

--- a/python/src/tests/storage/test_sql_chat_storage.py
+++ b/python/src/tests/storage/test_sql_chat_storage.py
@@ -1,0 +1,374 @@
+import os
+import pytest
+import tempfile
+import pytest_asyncio
+from multi_agent_orchestrator.storage import SqlChatStorage
+from multi_agent_orchestrator.types import ConversationMessage, ParticipantRole
+
+# Configure pytest-asyncio to use asyncio mode
+pytestmark = pytest.mark.asyncio
+
+@pytest_asyncio.fixture(scope="function")
+async def sql_storage():
+    """Create a temporary SQLite database for testing."""
+    with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as temp_db:
+        db_path = temp_db.name
+    
+    storage = SqlChatStorage(f"file:{db_path}")
+    await storage.initialize()
+    yield storage
+    
+    await storage.close()
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+@pytest.mark.asyncio
+async def test_save_and_fetch_message(sql_storage: SqlChatStorage):
+    """Test saving and fetching a single message."""
+    message = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{"text": "Hello, world!"}]
+    )
+    
+    # Save message
+    saved_messages = await sql_storage.save_chat_message(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent",
+        new_message=message
+    )
+    assert len(saved_messages) == 1
+    assert saved_messages[0].role == message.role
+    assert saved_messages[0].content == message.content
+
+    # Fetch and verify
+    messages = await sql_storage.fetch_chat(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent"
+    )
+    assert len(messages) == 1
+    assert messages[0].role == message.role
+    assert messages[0].content == message.content
+
+@pytest.mark.asyncio
+async def test_save_consecutive_same_role_messages(sql_storage: SqlChatStorage):
+    """Test that consecutive messages with the same role are not saved."""
+    message1 = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{"text": "First message"}]
+    )
+    message2 = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{"text": "Second message"}]
+    )
+    
+    # Save first message
+    saved_messages1 = await sql_storage.save_chat_message(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent",
+        new_message=message1
+    )
+    assert len(saved_messages1) == 1
+    assert saved_messages1[0].content == message1.content
+
+    # Try to save second message with same role
+    saved_messages2 = await sql_storage.save_chat_message(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent",
+        new_message=message2
+    )
+    assert len(saved_messages2) == 1
+    assert saved_messages2[0].content == message1.content
+
+    # Verify only first message was saved
+    messages = await sql_storage.fetch_chat(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent"
+    )
+    assert len(messages) == 1
+    assert messages[0].content == message1.content
+
+@pytest.mark.asyncio
+async def test_max_history_size(sql_storage: SqlChatStorage):
+    """Test that max_history_size properly limits the number of messages."""
+    messages = [
+        ConversationMessage(
+            role=ParticipantRole.USER.value if i % 2 == 0 else ParticipantRole.ASSISTANT.value,
+            content=[{"text": f"Message {i}"}]
+        ) for i in range(5)
+    ]
+    
+    # Save all messages
+    for msg in messages:
+        await sql_storage.save_chat_message(
+            user_id="test_user",
+            session_id="test_session",
+            agent_id="test_agent",
+            new_message=msg,
+            max_history_size=3
+        )
+    
+    # Verify only last 3 messages are kept
+    fetched = await sql_storage.fetch_chat(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent"
+    )
+    assert len(fetched) == 3
+    assert [m.content[0]["text"] for m in fetched] == ["Message 2", "Message 3", "Message 4"]
+
+@pytest.mark.asyncio
+async def test_save_multiple_messages(sql_storage: SqlChatStorage):
+    """Test saving multiple messages in a batch."""
+    messages = [
+        ConversationMessage(
+            role=ParticipantRole.USER.value if i % 2 == 0 else ParticipantRole.ASSISTANT.value,
+            content=[{"text": f"Message {i}"}]
+        ) for i in range(3)
+    ]
+    
+    # Save messages in batch
+    saved_messages = await sql_storage.save_chat_messages(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent",
+        new_messages=messages
+    )
+    assert len(saved_messages) == 3
+    for i, msg in enumerate(saved_messages):
+        assert msg.content[0]["text"] == f"Message {i}"
+
+    # Verify all messages were saved
+    fetched = await sql_storage.fetch_chat(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent"
+    )
+    assert len(fetched) == 3
+    for i, msg in enumerate(fetched):
+        assert msg.content[0]["text"] == f"Message {i}"
+
+@pytest.mark.asyncio
+async def test_fetch_all_chats(sql_storage: SqlChatStorage):
+    """Test fetching all chats across different agents."""
+    # Save messages for different agents
+    agents = ["agent1", "agent2"]
+    for agent_id in agents:
+        message = ConversationMessage(
+            role=ParticipantRole.ASSISTANT.value,
+            content=[{"text": f"Message from {agent_id}"}]
+        )
+        await sql_storage.save_chat_message(
+            user_id="test_user",
+            session_id="test_session",
+            agent_id=agent_id,
+            new_message=message
+        )
+    
+    # Fetch all chats
+    all_messages = await sql_storage.fetch_all_chats(
+        user_id="test_user",
+        session_id="test_session"
+    )
+    
+    assert len(all_messages) == 2
+    agent_messages = [msg.content[0]["text"] for msg in all_messages]
+    assert "[agent1] Message from agent1" in agent_messages
+    assert "[agent2] Message from agent2" in agent_messages
+
+@pytest.mark.asyncio
+async def test_multiple_users_and_sessions(sql_storage: SqlChatStorage):
+    """Test handling multiple users and sessions independently."""
+    test_cases = [
+        ("user1", "session1", "Hello from user1 session1"),
+        ("user1", "session2", "Hello from user1 session2"),
+        ("user2", "session1", "Hello from user2 session1")
+    ]
+    
+    # Save messages for different user/session combinations
+    for user_id, session_id, text in test_cases:
+        message = ConversationMessage(
+            role=ParticipantRole.USER.value,
+            content=[{"text": text}]
+        )
+        await sql_storage.save_chat_message(
+            user_id=user_id,
+            session_id=session_id,
+            agent_id="test_agent",
+            new_message=message
+        )
+    
+    # Verify each combination independently
+    for user_id, session_id, text in test_cases:
+        messages = await sql_storage.fetch_chat(
+            user_id=user_id,
+            session_id=session_id,
+            agent_id="test_agent"
+        )
+        assert len(messages) == 1
+        assert messages[0].content[0]["text"] == text
+
+@pytest.mark.asyncio
+async def test_empty_fetch(sql_storage: SqlChatStorage):
+    """Test fetching from empty storage."""
+    messages = await sql_storage.fetch_chat(
+        user_id="nonexistent",
+        session_id="nonexistent",
+        agent_id="nonexistent"
+    )
+    assert len(messages) == 0
+
+    all_messages = await sql_storage.fetch_all_chats(
+        user_id="nonexistent",
+        session_id="nonexistent"
+    )
+    assert len(all_messages) == 0
+
+@pytest.mark.asyncio
+async def test_save_empty_batch(sql_storage: SqlChatStorage):
+    """Test saving an empty batch of messages."""
+    saved_messages = await sql_storage.save_chat_messages(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent",
+        new_messages=[]
+    )
+    assert len(saved_messages) == 0
+
+@pytest.mark.asyncio
+async def test_message_ordering(sql_storage: SqlChatStorage):
+    """Test that messages are returned in correct chronological order."""
+    messages = [
+        ConversationMessage(
+            role=ParticipantRole.USER.value if i % 2 == 0 else ParticipantRole.ASSISTANT.value,
+            content=[{"text": f"Message {i}"}]
+        ) for i in range(5)
+    ]
+    
+    # Save messages one by one
+    for msg in messages:
+        await sql_storage.save_chat_message(
+            user_id="test_user",
+            session_id="test_session",
+            agent_id="test_agent",
+            new_message=msg
+        )
+    
+    # Verify order with and without max_history_size
+    full_history = await sql_storage.fetch_chat(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent"
+    )
+    assert [m.content[0]["text"] for m in full_history] == [f"Message {i}" for i in range(5)]
+    
+    limited_history = await sql_storage.fetch_chat(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent",
+        max_history_size=3
+    )
+    assert [m.content[0]["text"] for m in limited_history] == [f"Message {i}" for i in range(2, 5)] 
+
+@pytest.mark.asyncio
+async def test_invalid_database_url():
+    """Test handling of invalid database URL."""
+    with pytest.raises(Exception):
+        storage = SqlChatStorage("invalid://url")
+        await storage.initialize()
+
+@pytest.mark.asyncio
+async def test_concurrent_access(sql_storage: SqlChatStorage):
+    """Test concurrent access to the database."""
+    import asyncio
+    
+    async def save_message(i: int):
+        message = ConversationMessage(
+            role=ParticipantRole.USER.value,
+            content=[{"text": f"Concurrent message {i}"}]
+        )
+        await sql_storage.save_chat_message(
+            user_id="test_user",
+            session_id="test_session",
+            agent_id=f"agent{i}",
+            new_message=message
+        )
+    
+    # Run multiple saves concurrently
+    await asyncio.gather(*[save_message(i) for i in range(5)])
+    
+    # Verify all messages were saved
+    all_messages = await sql_storage.fetch_all_chats(
+        user_id="test_user",
+        session_id="test_session"
+    )
+    assert len(all_messages) == 5
+    messages = [msg.content[0]["text"] for msg in all_messages]
+    for i in range(5):
+        assert f"Concurrent message {i}" in messages
+
+@pytest.mark.asyncio
+async def test_transaction_rollback(sql_storage: SqlChatStorage):
+    """Test transaction rollback on error."""
+    messages = [
+        ConversationMessage(
+            role=ParticipantRole.USER.value,
+            content=[{"text": "Valid message"}]
+        ),
+        ConversationMessage(
+            role=ParticipantRole.USER.value,
+            content=None  # This will cause a JSON serialization error
+        )
+    ]
+    
+    # Attempt to save messages that will cause an error
+    with pytest.raises(Exception):
+        await sql_storage.save_chat_messages(
+            user_id="test_user",
+            session_id="test_session",
+            agent_id="test_agent",
+            new_messages=messages
+        )
+    
+    # Verify no messages were saved due to transaction rollback
+    saved_messages = await sql_storage.fetch_chat(
+        user_id="test_user",
+        session_id="test_session",
+        agent_id="test_agent"
+    )
+    assert len(saved_messages) == 0
+
+@pytest.mark.asyncio
+async def test_database_connection_handling():
+    """Test proper handling of database connections."""
+    with tempfile.NamedTemporaryFile(suffix='.db') as temp_db:
+        storage = SqlChatStorage(f"file:{temp_db.name}")
+        await storage.initialize()
+        
+        # Test basic operation
+        message = ConversationMessage(
+            role=ParticipantRole.USER.value,
+            content=[{"text": "Test message"}]
+        )
+        await storage.save_chat_message(
+            user_id="test_user",
+            session_id="test_session",
+            agent_id="test_agent",
+            new_message=message
+        )
+        
+        # Close connection
+        await storage.close()
+        
+        # Verify operations fail after close
+        with pytest.raises(Exception):
+            await storage.save_chat_message(
+                user_id="test_user",
+                session_id="test_session",
+                agent_id="test_agent",
+                new_message=message
+            ) 

--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -6,3 +6,4 @@ moto
 pytest-mock
 pytest-asyncio
 openai
+libsql-client


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue:** https://github.com/awslabs/multi-agent-orchestrator/pull/111#issuecomment-2582329631

## Summary

### Changes

- Implemented the newly added abstract method `save_chat_messages`, introduced in commit cd46dad2e08c68e6eaad9b484e2c58952e3143de but previously missing in `SQLChatStorage`.
- Resolved async/sync inconsistencies within SQLChatStorage.
- Added tests to prevent and detect future breaking changes.
- Updated documentation to reflect changes in the Python `SQLChatStorage` implementation.

### User Experience

- Improved the overall reliability of `SQLChatStorage` to safeguard against future breaking changes.

## Checklist

If your change doesn't seem to apply, please leave it unchecked.

* [x] I have performed a self-review of this change.
* [x] Changes have been tested.
* [x] Changes are documented.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.