### PR TITLE
Adding note in quickstart docs section about TypeScript deployments

### DIFF
--- a/docs/src/content/docs/general/quickstart.mdx
+++ b/docs/src/content/docs/general/quickstart.mdx
@@ -98,6 +98,12 @@ Ensure you have [requested access](https://docs.aws.amazon.com/bedrock/latest/us
   </TabItem>
 </Tabs>
 
+Note: When working with TypeScript some CDK deployments may require you to install `esbuild` as well.
+
+```bash
+npm install esbuild
+```
+
 2. Create a new file for your quickstart code:
 
 <Tabs syncKey="runtime">


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
## Summary

Added a note in the "Get Started" part of the Quickstart section about the `esbuild` package that may be required for CDK deployments.

### Changes

Docs added to simply recommend a solution for TypeScript CDK installations.

### User experience

Our CDK deployments in a personal project, having `"multi-agent-orchestrator": "^0.1.3"` as dependency, failed with an unclear reason. After investigation we found out that adding `esbuild` dependency in the package.json was the solution.
So I believe is a good idea to add a note on the installation section of documentation to help users avoid this friction.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
