### PR TITLE
Missing tool and tool exception handling

### DIFF
--- a/python/src/multi_agent_orchestrator/utils/tool.py
+++ b/python/src/multi_agent_orchestrator/utils/tool.py
@@ -204,7 +204,10 @@ class AgentTools:
             )
 
             # Process the tool use
-            result = await self._process_tool(tool_name, input_data)
+            try:
+                result = await self._process_tool(tool_name, input_data)
+            except Exception as e:
+                result = str(e)
 
             # Create tool result
             tool_result = AgentToolResult(tool_id, result)
@@ -243,7 +246,9 @@ class AgentTools:
             tool = next(tool for tool in self.tools if tool.name == tool_name)
             return tool.func(**input_data)
         except StopIteration:
-            return (f"Tool '{tool_name}' not found")
+            raise ValueError(f"Tool '{tool_name}' not found")
+        except Exception as e:
+            raise Exception(f"Tool '{tool_name}' returned an error: {str(e)}")
 
     def to_claude_format(self) -> list[dict[str, Any]]:
         """Convert all tools to Claude format"""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #250 

## Summary

Missing tools should return a message that a requested tool was not found. Tools that throw exceptions should be properly caught and returned.

### Changes

`_process_tool` in tools.py will raise exceptions for missing tools and tool invocation exceptions. `tool_handler` will catch these exceptions and report them back.

### User experience

It works.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
