### PR TITLE
Refactor dispatch_to_agent call to use named parameters

### DIFF
--- a/python/src/multi_agent_orchestrator/orchestrator.py
+++ b/python/src/multi_agent_orchestrator/orchestrator.py
@@ -138,7 +138,7 @@ class MultiAgentOrchestrator:
                                additional_params: Dict[str, str] = {}) -> AgentResponse:
         """Process agent response and handle chat storage."""
         try:
-            agent_response = await self.dispatch_to_agent({
+            agent_response = await self.dispatch_to_agent(params={
                 "user_input": user_input,
                 "user_id": user_id,
                 "session_id": session_id,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

## Summary

### Changes
> Refactored the `dispatch_to_agent` function call to use named parameters for better readability and maintainability. The `params` dictionary now explicitly names the parameters being passed.

### User experience

> **Before:**
> ```python
> agent_response = await self.dispatch_to_agent({
>     "user_input": user_input,
>     "user_id": user_id,
>     "session_id": session_id,
>     "classifier_result": classifier_result,
>     "additional_params": additional_params
> })
> ```

> **After:**
> ```python
> agent_response = await self.dispatch_to_agent(params={
>     "user_input": user_input,
>     "user_id": user_id,
>     "session_id": session_id,
>     "classifier_result": classifier_result,
>     "additional_params": additional_params
> })
> ```

> The change makes it clear that the dictionary being passed is specifically for the `params` parameter, improving code readability and making the intention of the code more understandable.


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary> NO

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
