### PR TITLE
fix: Add missing maxHistorySize parameter in streaming conversation save

### DIFF
--- a/typescript/src/orchestrator.ts
+++ b/typescript/src/orchestrator.ts
@@ -484,7 +484,8 @@ export class AgentSquad {
           this.storage,
           userId,
           sessionId,
-          agent.id
+          agent.id,
+          this.config.MAX_MESSAGE_PAIRS_PER_AGENT
         );
       }
 


### PR DESCRIPTION
This PR fixes a bug where streaming responses in Agent Squad don't save conversation history with the configured `MAX_MESSAGE_PAIRS_PER_AGENT` limit, potentially causing unlimited memory growth.

This fix ensures that conversation history is properly limited in streaming scenarios, preventing potential memory issues from unlimited message accumulation.

<!-- markdownlint-disable MD041 MD043 -->
## Issue Link (REQUIRED)
<!-- This PR must be linked to an issue. PRs without a linked issue will not be merged. -->
Fixes #365 

## Summary
The processStreamInBackground method was not passing the MAX_MESSAGE_PAIRS_PER_AGENT parameter to saveConversationExchange, while the non-streaming code path correctly included it. This inconsistency could lead to unlimited message history growth in streaming scenarios.

### Changes
<!-- Please provide a summary of what's being changed -->
- Add missing maxHistorySize parameter to saveConversationExchange call in processStreamInBackground
- Add unit test to verify streaming responses save conversation history with correct maxHistorySize
- Test ensures the bug is fixed and prevents regression

In the `processStreamInBackground` method of `orchestrator.ts`, the call to `saveConversationExchange` was missing the `maxHistorySize` parameter:

```typescript
// Before (line 487-489)
await saveConversationExchange(
  userInput,
  fullResponse,
  this.storage,
  userId,
  sessionId,
  agent.id
  // Missing: this.config.MAX_MESSAGE_PAIRS_PER_AGENT
);
```

The non-streaming code path correctly includes this parameter, creating an inconsistency that could lead to:

- Unlimited conversation history growth for streaming responses
- Memory issues in long-running sessions
- Inconsistent behavior between streaming and non-streaming modes

#### Solution

This PR adds the missing parameter to ensure consistent behavior:

```typescript
// After
await saveConversationExchange(
  userInput,
  fullResponse,
  this.storage,
  userId,
  sessionId,
  agent.id,
  this.config.MAX_MESSAGE_PAIRS_PER_AGENT
);
```

### User experience
<!-- Please share what the user experience looks like before and after this change -->
After the fix, the user having long conversations with the AI app can successfully maintain conversation context (remember past conversation details) across multiple conversation turns while not having the risk of memory leak on the server to crash the server.
The operator of the agent squad backend won't get alarms on memory leak.

## Checklist
If your change doesn't seem to apply, please leave them unchecked.
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] I have linked this PR to an existing issue (required)

<details>
<summary>Is this a breaking change?</summary>
This is not a breaking change

**RFC issue number**:

Checklist:
* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)
</details>

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.