### PR TITLE
feat: Add protected setDocClient method to DynamoDbChatStorage

### DIFF
--- a/typescript/src/common/src/version.ts
+++ b/typescript/src/common/src/version.ts
@@ -1,2 +1,2 @@
 // this file is auto generated, do not modify
-export const MAOTS_VERSION = '1.0.0';
+export const MAOTS_VERSION = '1.0.1';

--- a/typescript/src/storage/dynamoDbChatStorage.ts
+++ b/typescript/src/storage/dynamoDbChatStorage.ts
@@ -26,6 +26,16 @@ export class DynamoDbChatStorage extends ChatStorage {
     this.docClient = DynamoDBDocumentClient.from(client);
   }
 
+  /**
+   * Allows subclasses to customize the DynamoDB Document Client.
+   * Useful for local development, testing, or custom endpoint configurations.
+   * @param client - The DynamoDBDocumentClient to use
+   * @protected
+   */
+  protected setDocClient(client: DynamoDBDocumentClient): void {
+    this.docClient = client;
+  }
+
   async saveChatMessage(
     userId: string,
     sessionId: string,

--- a/typescript/tests/storage/DynamoDbChatStorage.test.ts
+++ b/typescript/tests/storage/DynamoDbChatStorage.test.ts
@@ -1,0 +1,121 @@
+import { DynamoDbChatStorage } from "../../src/storage/dynamoDbChatStorage";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { ConversationMessage, ParticipantRole } from "../../src/types";
+
+// Mock AWS SDK
+jest.mock("@aws-sdk/client-dynamodb");
+jest.mock("@aws-sdk/lib-dynamodb", () => ({
+  DynamoDBDocumentClient: {
+    from: jest.fn(),
+  },
+  PutCommand: jest.fn(),
+  GetCommand: jest.fn(),
+  QueryCommand: jest.fn(),
+}));
+
+describe("DynamoDbChatStorage", () => {
+  let storage: DynamoDbChatStorage;
+  let mockDocClient: jest.Mocked<DynamoDBDocumentClient>;
+  
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+    
+    // Create mock document client
+    mockDocClient = {
+      send: jest.fn().mockResolvedValue({ Item: { conversation: [] } }),
+    } as any;
+    
+    // Mock DynamoDBDocumentClient.from to return our mock
+    (DynamoDBDocumentClient.from as jest.Mock).mockReturnValue(mockDocClient);
+    
+    // Create storage instance
+    storage = new DynamoDbChatStorage("test-table", "us-east-1", "ttl", 3600);
+  });
+
+  describe("setDocClient", () => {
+    it("should allow subclasses to override the document client", async () => {
+      // Create a mock custom document client
+      const customDocClient = {
+        send: jest.fn().mockResolvedValue({ Item: { conversation: [] } }),
+      } as any;
+      
+      // Create a test subclass that uses setDocClient
+      class TestDynamoDbChatStorage extends DynamoDbChatStorage {
+        constructor(tableName: string, region: string) {
+          super(tableName, region);
+          // Use the protected method to set custom client
+          this.setDocClient(customDocClient);
+        }
+      }
+      
+      // Create instance of subclass
+      const testStorage = new TestDynamoDbChatStorage("test-table", "us-east-1");
+      
+      // Call a method that uses the document client
+      await testStorage.fetchChat("user1", "session1", "agent1");
+      
+      // Verify that the custom client was used, not the original mock
+      expect(customDocClient.send).toHaveBeenCalled();
+      expect(mockDocClient.send).not.toHaveBeenCalled();
+    });
+
+    it("should work correctly for local development scenario", async () => {
+      // Mock a local document client
+      const localDocClient = {
+        send: jest.fn()
+          .mockResolvedValueOnce({ Item: { conversation: [] } }) // for fetchChat
+          .mockResolvedValueOnce({}), // for saveChatMessage
+      } as any;
+      
+      // Override the mock to return local client for the second call
+      let callCount = 0;
+      (DynamoDBDocumentClient.from as jest.Mock).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return mockDocClient; // First call in parent constructor
+        }
+        return localDocClient; // Second call in subclass
+      });
+      
+      // Simulate local development setup
+      class LocalDynamoDbChatStorage extends DynamoDbChatStorage {
+        constructor(tableName: string, region: string, endpoint: string) {
+          super(tableName, region);
+          
+          const client = new DynamoDBClient({
+            region,
+            endpoint,
+            credentials: {
+              accessKeyId: "dummy",
+              secretAccessKey: "dummy",
+            },
+          });
+          
+          this.setDocClient(DynamoDBDocumentClient.from(client));
+        }
+      }
+      
+      const localStorage = new LocalDynamoDbChatStorage(
+        "local-table",
+        "us-east-1",
+        "http://localhost:8000"
+      );
+      
+      // Create and save a message
+      const message: ConversationMessage = {
+        role: ParticipantRole.USER,
+        content: [{ text: "Hello" }],
+      };
+      
+      // This should use the custom client with local endpoint
+      const result = await localStorage.saveChatMessage("user1", "session1", "agent1", message);
+      
+      // Verify the local client was called
+      expect(localDocClient.send).toHaveBeenCalledTimes(2); // Once for fetchChat, once for putCommand
+      expect(mockDocClient.send).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Issue Link (REQUIRED)
Fixes #368

## Summary
### Changes
Added a protected `setDocClient` method to the `DynamoDbChatStorage` class, allowing subclasses to customize the DynamoDB Document Client configuration. This enhancement enables common use cases without requiring code duplication.

**Key benefit**: This change enables developers to use DynamoDB Local in Docker containers for local development, eliminating the need for AWS credentials and costs during development.

### User experience
**Before**: Users had to duplicate the entire DynamoDbChatStorage class (~200+ lines) or use type casting hacks to customize the DynamoDB client for local development or testing.

**After**: Users can cleanly extend DynamoDbChatStorage with minimal code:

#### Example: Local Development with DynamoDB in Docker
```typescript
// Start DynamoDB Local in Docker:
// docker run -p 8000:8000 amazon/dynamodb-local

class LocalDynamoDbChatStorage extends DynamoDbChatStorage {
  constructor(tableName: string, region: string, endpoint: string) {
    super(tableName, region);
    
    const client = new DynamoDBClient({
      region,
      endpoint,  // e.g., 'http://localhost:8000'
      credentials: { accessKeyId: 'dummy', secretAccessKey: 'dummy' }
    });
    
    this.setDocClient(DynamoDBDocumentClient.from(client));
  }
}

// Usage
const storage = new LocalDynamoDbChatStorage(
  'conversations-table',
  'us-east-1',
  'http://localhost:8000'  // Points to Docker container
);
```

## Checklist
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] I have linked this PR to an existing issue (required)

<details>
<summary>Is this a breaking change?</summary>

No, this is a non-breaking change. The new protected method is additive and all existing code continues to work unchanged.

**RFC issue number**: N/A

Checklist:
* [ ] Migration process documented (N/A - non-breaking)
* [ ] Implement warnings (N/A - non-breaking)
</details>

## Testing

- Added comprehensive unit tests for the new method
- All existing tests continue to pass
- Tested with local DynamoDB setup in Docker container
- Verified the following Docker setup works:
  ```bash
  # Start DynamoDB Local
  docker run -d -p 8000:8000 amazon/dynamodb-local
  
  # Create table
  aws dynamodb create-table \
    --table-name conversations-table \
    --attribute-definitions \
      AttributeName=PK,AttributeType=S \
      AttributeName=SK,AttributeType=S \
    --key-schema \
      AttributeName=PK,KeyType=HASH \
      AttributeName=SK,KeyType=RANGE \
    --billing-mode PAY_PER_REQUEST \
    --endpoint-url http://localhost:8000
  ```

## Documentation

Added JSDoc documentation for the new method explaining its purpose and usage.

## Real-World Benefits

This change significantly improves the developer experience by enabling:

1. **Cost-free local development** - No AWS charges during development
2. **Offline development** - Works without internet connection
3. **Faster iteration** - No network latency to AWS
4. **CI/CD testing** - Easy integration testing with DynamoDB Local in Docker
5. **Docker Compose workflows** - Seamless integration with containerized development environments

Example docker-compose.yml:
```yaml
services:
  dynamodb-local:
    image: amazon/dynamodb-local
    ports:
      - "8000:8000"
  
  app:
    build: .
    environment:
      DYNAMODB_ENDPOINT: http://dynamodb-local:8000
    depends_on:
      - dynamodb-local
```

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.