### PR TITLE
Fix toolInUse initialization to correctly detect tool usage

### DIFF
--- a/python/src/agent_squad/agents/bedrock_llm_agent.py
+++ b/python/src/agent_squad/agents/bedrock_llm_agent.py
@@ -387,8 +387,8 @@ class BedrockLLMAgent(Agent):
                 if isinstance(item, dict) and "text" in item:
                     content.append(item)
 
-            toolInUse=True
-            # Go through response content and save text items
+            toolInUse = False
+            # Go through response content and save toolUse items
             for item in response_content:
                 if isinstance(item, dict) and "toolUse" in item:
                     content.append(item)
@@ -398,7 +398,7 @@ class BedrockLLMAgent(Agent):
             if toolInUse:
                 if thinking_content:
                     content.insert(0,{"reasoningContent": thinking_content})
-            else:
+            elif thinking_content:
                 content.append({"reasoningContent": thinking_content})
 
             kwargs = {
@@ -520,8 +520,8 @@ class BedrockLLMAgent(Agent):
                 if isinstance(item, dict) and "text" in item:
                     _content.append(item)
 
-            toolInUse=True
-            # Go through response content and save text items
+            toolInUse = False
+            # Go through response content and save toolUse items
             for item in response_content:
                 if isinstance(item, dict) and "toolUse" in item:
                     _content.append(item)
@@ -531,7 +531,7 @@ class BedrockLLMAgent(Agent):
             if toolInUse:
                 if accumulated_thinking:
                     _content.insert(0,{"reasoningContent": {"reasoningText": {"text": accumulated_thinking, "signature":thinking_signature}}})
-            else:
+            elif accumulated_thinking:
                 _content.append({"reasoningContent": {"reasoningText": {"text": accumulated_thinking, "signature":thinking_signature}}})
 
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in `bedrock_llm_agent.py` where the `toolInUse` variable was incorrectly initialized to `True` before the loop that checks for tool usage, making it always `True` regardless of whether a tool was actually used.

## Bug Description

In both `handle_single_response` and `handle_streaming_response` methods:

```python
# Before fix (incorrect)
toolInUse=True  # Bug: always True
for item in response_content:
    if isinstance(item, dict) and "toolUse" in item:
        content.append(item)
        toolInUse = True  # Redundant, already True
```

This caused `reasoningContent` (thinking content) to always be inserted at index 0 of the content array, even when no tool was being used. According to the code comment, reasoning content should only be inserted at index 0 when a tool is used, and appended otherwise.

## Fix

- Changed `toolInUse = True` to `toolInUse = False` to correctly initialize the variable
- Added a check for `thinking_content`/`accumulated_thinking` before appending to avoid appending `None` values when there is no thinking content
- Updated comment to correctly describe the loop's purpose (saving "toolUse items" not "text items")

## Impact

When extended thinking is enabled and no tool is used, the `reasoningContent` will now be correctly appended to the content array instead of being inserted at the beginning.