### PR TITLE
fix: ComprehendFilterAgent client initialization and on_llm_start docstring

### DIFF
--- a/python/src/agent_squad/agents/agent.py
+++ b/python/src/agent_squad/agents/agent.py
@@ -146,11 +146,10 @@ class AgentCallbacks:
 
         Parameters:
             self: The instance of the callback handler class.
-            agent_name: Name of the agent that is starting.
-            payload_input: Dictionary containing the agent's input.
-            messages: List of message dictionaries representing the conversation history.
-            run_id: Unique identifier for this specific agent run.
-            tags: Optional list of string tags associated with this agent run.
+            name: Name of the LLM that is starting.
+            payload_input: Dictionary containing the LLM's input.
+            run_id: Unique identifier for this specific LLM run.
+            tags: Optional list of string tags associated with this LLM run.
             metadata: Optional dictionary containing additional metadata about the run.
             **kwargs: Additional keyword arguments that might be passed to the callback.
 

--- a/python/src/agent_squad/agents/comprehend_filter_agent.py
+++ b/python/src/agent_squad/agents/comprehend_filter_agent.py
@@ -31,12 +31,12 @@ class ComprehendFilterAgent(Agent):
             self.comprehend_client = options.client
         else:
             if options.region:
-                self.client = boto3.client(
+                self.comprehend_client = boto3.client(
                     'comprehend',
                     region_name=options.region or os.environ.get('AWS_REGION')
                 )
             else:
-                self.client = boto3.client('comprehend')
+                self.comprehend_client = boto3.client('comprehend')
 
         self.custom_checks: list[CheckFunction] = []
 

--- a/python/src/tests/agents/test_comprehend_agent.py
+++ b/python/src/tests/agents/test_comprehend_agent.py
@@ -216,5 +216,45 @@ class TestComprehendFilterAgent(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent.sentiment_threshold, 0.5)
         self.assertEqual(agent.toxicity_threshold, 0.8)
 
+    async def test_initialization_without_client_uses_comprehend_client(self):
+        """Test that comprehend_client is correctly set when no client is passed.
+
+        This regression test verifies the fix for issue #359 where passing
+        client=None would cause an AttributeError because the boto3 client
+        was incorrectly assigned to self.client instead of self.comprehend_client.
+        """
+        from unittest.mock import patch, MagicMock
+
+        mock_boto_client = MagicMock()
+        with patch('boto3.client', return_value=mock_boto_client) as mock_boto:
+            # Test with region specified
+            agent_with_region = ComprehendFilterAgent(
+                ComprehendFilterAgentOptions(
+                    name="Test Filter Agent",
+                    description="Test agent",
+                    client=None,
+                    region="us-east-1"
+                )
+            )
+            # Verify comprehend_client attribute exists and is set correctly
+            self.assertTrue(hasattr(agent_with_region, 'comprehend_client'))
+            self.assertEqual(agent_with_region.comprehend_client, mock_boto_client)
+            mock_boto.assert_called_with('comprehend', region_name='us-east-1')
+
+        with patch('boto3.client', return_value=mock_boto_client) as mock_boto:
+            # Test without region (uses default)
+            agent_without_region = ComprehendFilterAgent(
+                ComprehendFilterAgentOptions(
+                    name="Test Filter Agent",
+                    description="Test agent",
+                    client=None,
+                    region=None
+                )
+            )
+            # Verify comprehend_client attribute exists and is set correctly
+            self.assertTrue(hasattr(agent_without_region, 'comprehend_client'))
+            self.assertEqual(agent_without_region.comprehend_client, mock_boto_client)
+            mock_boto.assert_called_with('comprehend')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

This PR fixes two bugs reported in issues #359 and #360:

### Issue #359 - ComprehendFilterAgent missing client initialization
When creating a `ComprehendFilterAgent` without passing an explicit client (relying on boto3 to create one), the agent would fail with `AttributeError: 'ComprehendFilterAgent' object has no attribute 'comprehend_client'`.

**Root cause:** Lines 34 and 39 in `comprehend_filter_agent.py` incorrectly assigned the boto3 client to `self.client` instead of `self.comprehend_client`.

**Fix:** Changed `self.client` to `self.comprehend_client` in both branches of the initialization logic.

### Issue #360 - Documentation bug in on_llm_start callback
The docstring for `on_llm_start` in `agent.py` documented parameters that didn't match the actual method signature:
- `agent_name` (should be `name`)
- `messages` (not a parameter of this method)

**Fix:** Updated docstring to accurately reflect the method signature and context (LLM vs agent).

## Test plan
- [x] Added regression test `test_initialization_without_client_uses_comprehend_client` to verify `comprehend_client` is properly set when initializing without explicit client
- [x] All 11 tests in `test_comprehend_agent.py` pass
- [x] Verified docstring now matches method signature

## Reproduction (Issue #359)
Before this fix, the following code would fail:
```python
filter_agent = ComprehendFilterAgent(
    ComprehendFilterAgentOptions(
        name="Filter agent",
        description="Analyzes content",
        client=None,
        region="us-east-1"
    )
)
await filter_agent.process_request("test", "user", "session", [])
# AttributeError: 'ComprehendFilterAgent' object has no attribute 'comprehend_client'
```

After this fix, the agent correctly initializes and processes requests.

Fixes #359
Fixes #360