### PR TITLE
docs: add missing python logging examples

### DIFF
--- a/docs/src/content/docs/cookbook/monitoring/logging.mdx
+++ b/docs/src/content/docs/cookbook/monitoring/logging.mdx
@@ -33,7 +33,16 @@ export interface OrchestratorOptions {
   </TabItem>
   <TabItem label="Python" icon="seti:python">
 ```python
-// TODO: Add python code here
+class AgentSquad:
+    def __init__(
+        self,
+        options: AgentSquadConfig | dict | None = None,
+        storage: ChatStorage | None = None,
+        classifier: Classifier | None = None,
+        logger: Logger | None = None,
+        default_agent: Agent | None = None,
+    ):
+        ...
 ```
   </TabItem>
 </Tabs>
@@ -56,8 +65,8 @@ npm install @aws-lambda-powertools/logger
 
   </TabItem>
   <TabItem label="Python" icon="seti:python">
-```python
-// TODO: Add python code here
+```bash
+pip install aws-lambda-powertools
 ```
   </TabItem>
 </Tabs>
@@ -81,7 +90,12 @@ const logger = new Logger({
   </TabItem>
   <TabItem label="Python" icon="seti:python">
 ```python
-// TODO: Add python code here
+from aws_lambda_powertools import Logger
+
+logger = Logger(
+    level="INFO",
+    service="MyOrchestratorService"
+)
 ```
   </TabItem>
 </Tabs>
@@ -109,7 +123,18 @@ const orchestrator = new AgentSquad({
   </TabItem>
   <TabItem label="Python" icon="seti:python">
 ```python
-// TODO: Add python code here
+from agent_squad.orchestrator import AgentSquad
+
+orchestrator = AgentSquad(
+    options={
+        "LOG_AGENT_CHAT": True,
+        "LOG_CLASSIFIER_CHAT": True,
+        "LOG_CLASSIFIER_RAW_OUTPUT": True,
+        "LOG_CLASSIFIER_OUTPUT": True,
+        "LOG_EXECUTION_TIMES": True,
+    },
+    logger=logger,
+)
 ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Issue Link (REQUIRED)
  Fixes #439

  ## Summary
  ### Changes
  - Replaced 4 TODO placeholders in `docs/src/content/docs/cookbook/monitoring/
  logging.mdx`
  - Added Python snippets for:
    - AgentSquad constructor options/logger
    - Installing AWS Lambda Powertools
    - Logger initialization
    - AgentSquad initialization with logging flags

  ### User experience
  Before: Python tabs in logging docs had TODO placeholders.
  After: Python tabs provide complete, copy-paste ready examples.

  ## Checklist
  - [x] I have performed a self-review of this change
  - [ ] Changes have been tested
  - [x] Changes are documented
  - [x] I have linked this PR to an existing issue (required)

  ## Acknowledgment
  By submitting this pull request, I confirm that you can use, modify, copy, and
  redistribute this contribution, under the terms of your choice.