### PR TITLE
fix(orchestrator): pass MAX_MESSAGE_PAIRS_PER_AGENT in streaming path

### DIFF
--- a/typescript/src/orchestrator.ts
+++ b/typescript/src/orchestrator.ts
@@ -536,7 +536,8 @@ export class AgentSquad {
             this.storage,
             userId,
             sessionId,
-            agent.id
+            agent.id,
+            this.config.MAX_MESSAGE_PAIRS_PER_AGENT
           );
         }
       } else {


### PR DESCRIPTION
## Problem

Streaming responses do not respect MAX_MESSAGE_PAIRS_PER_AGENT configuration (#365). The processStreamInBackground method calls saveConversationExchange without the maxHistorySize parameter, causing unbounded conversation history growth.

## Fix

Added the missing this.config.MAX_MESSAGE_PAIRS_PER_AGENT parameter to the saveConversationExchange call in the streaming code path.

Non-streaming path already passed this parameter correctly.

## Changes

- typescript/src/orchestrator.ts: 1-line addition

Closes #365