### PR TITLE
fix: prevent IndexError when content is empty after tool recursion (#355)

### DIFF
--- a/python/src/agent_squad/agents/anthropic_agent.py
+++ b/python/src/agent_squad/agents/anthropic_agent.py
@@ -234,14 +234,19 @@ class AnthropicAgent(Agent):
                     # Create content list with text from final_response
                     content_list = []
 
-                    # Add text content, filter out empty items
-                    for content in final_response.content:
-                        if hasattr(content, 'text') and content.text:
-                            content_list.append({"text": content.text})
+                    if final_response:
+                        # Add text content, filter out empty items
+                        for content in final_response.content:
+                            if hasattr(content, 'text') and content.text:
+                                content_list.append({"text": content.text})
 
                     # Add thinking to the content if it exists
                     if accumulated_thinking:
                         content_list.append({"thinking": accumulated_thinking})
+
+                    # Ensure content is never empty
+                    if not content_list:
+                        content_list.append({"text": "Maximum tool recursion limit reached without a final response."})
 
                     yield AgentStreamResponse(
                         final_message=ConversationMessage(
@@ -320,6 +325,9 @@ class AnthropicAgent(Agent):
                 llm_content = llm_response.content or [{"text": "No final response generated"}]
 
             max_recursions -= 1
+
+        if llm_content is None:
+            llm_content = [{"text": "Maximum tool recursion limit reached without a final response."}]
 
         return ConversationMessage(role=ParticipantRole.ASSISTANT.value, content=llm_content)
 

--- a/python/src/agent_squad/agents/bedrock_llm_agent.py
+++ b/python/src/agent_squad/agents/bedrock_llm_agent.py
@@ -224,6 +224,13 @@ class BedrockLLMAgent(Agent):
                 agent_tracking_info = {}
             agent_tracking_info["final_thinking"] = accumulated_thinking
 
+        # If max_recursions exhausted during tool loop, llm_response may contain tool_use blocks
+        if llm_response and any("toolUse" in content for content in llm_response.content):
+            llm_response = ConversationMessage(
+                role=ParticipantRole.ASSISTANT.value,
+                content=[{"text": "Maximum tool recursion limit reached without a final response."}]
+            )
+
         return llm_response
 
     async def _handle_streaming(
@@ -261,10 +268,19 @@ class BedrockLLMAgent(Agent):
 
                     conversation.append(tool_response)
                     command["messages"] = conversation_to_dict(conversation)
+                    # Clear final_response so we detect max_recursion exhaustion after loop
+                    final_response = None
                 else:
                     continue_with_tools = False
 
                 max_recursions -= 1
+
+            # If max_recursions exhausted during tool loop, final_response is None
+            if final_response is None:
+                final_response = ConversationMessage(
+                    role=ParticipantRole.ASSISTANT.value,
+                    content=[{"text": "Maximum tool recursion limit reached without a final response."}]
+                )
 
             kwargs = {
                 "agent_name": self.name,

--- a/typescript/src/agents/anthropicAgent.ts
+++ b/typescript/src/agents/anthropicAgent.ts
@@ -264,7 +264,7 @@ export class AnthropicAgent extends Agent {
         message.role === ParticipantRole.USER
           ? ParticipantRole.USER
           : ParticipantRole.ASSISTANT,
-      content: message.content![0]["text"] || "", // Fallback to empty string if content is undefined
+      content: message.content?.[0]?.["text"] || "", // Fallback to empty string if content is undefined or empty
     }));
     messages.push({ role: ParticipantRole.USER, content: inputText });
 

--- a/typescript/src/agents/bedrockLLMAgent.ts
+++ b/typescript/src/agents/bedrockLLMAgent.ts
@@ -391,6 +391,15 @@ export class BedrockLLMAgent extends Agent {
 
           converseCmd.messages = conversation;
         } while (continueWithTools && maxRecursions > 0);
+
+        // If maxRecursions exhausted during tool loop, finalMessage may be null or contain toolUse blocks
+        if (!finalMessage || finalMessage.content?.some((c: any) => 'toolUse' in c)) {
+          return {
+            role: ParticipantRole.ASSISTANT,
+            content: [{ text: "Maximum tool recursion limit reached without a final response." }]
+          } as ConversationMessage;
+        }
+
         return finalMessage;
       }
     } catch (error) {


### PR DESCRIPTION
## Problem

When `max_recursions` is exhausted during the tool execution loop, the agent returns a `ConversationMessage` with either:
- `content=None` (Python AnthropicAgent)
- `content` containing tool_use blocks instead of text (Python/TypeScript BedrockLLMAgent)
- `content=[]` after filtering (Python AnthropicAgent streaming)

This causes `IndexError: list index out of range` when callers access `response.output.content[0]['text']`.

Issue #355 reports this happening intermittently with the SupervisorAgent, which delegates to lead agents that use tool recursion.

## Root Cause

In the tool recursion loop:
```python
while continue_with_tools and max_recursions > 0:
    # ... tool processing ...
    max_recursions -= 1

return ConversationMessage(content=llm_content)  # llm_content is None!
```

When `max_recursions` hits 0 inside the loop while processing tool calls, `llm_content` (or equivalent) never gets assigned a text response.

## Fix

Added fallback handling in all 4 affected code paths:

**Python:**
- `AnthropicAgent._handle_single_response_loop`: Guard `llm_content is None` after loop
- `AnthropicAgent._handle_streaming`: Guard empty `content_list` after filtering
- `BedrockLLMAgent._handle_single_response_loop`: Detect tool_use content in final response
- `BedrockLLMAgent._handle_streaming`: Detect `None` final_response after loop

**TypeScript:**
- `AnthropicAgent.processRequest`: Safe optional chaining for `message.content?.[0]?.["text"]`
- `BedrockLLMAgent.processRequest`: Detect null/tool_use `finalMessage` after loop

All fallbacks return `"Maximum tool recursion limit reached without a final response."` instead of crashing.

Fixes #355