### PR TITLE
Fix SupervisorAgent crash when agent response is a dict

### DIFF
--- a/python/src/agent_squad/agents/supervisor_agent.py
+++ b/python/src/agent_squad/agents/supervisor_agent.py
@@ -180,7 +180,13 @@ When communicating with other agents, including the User, please follow these gu
         async for chunk in response:
             if isinstance(chunk, AgentStreamResponse):
                 if chunk.final_message:
-                    final_response = chunk.final_message.content[0].get('text', '')
+                    msg = chunk.final_message
+                    if isinstance(msg, ConversationMessage) and msg.content:
+                        final_response = msg.content[0].get('text', '')
+                    elif isinstance(msg, dict):
+                        content = msg.get('content', [])
+                        if content and isinstance(content[0], dict):
+                            final_response = content[0].get('text', '')
         return final_response
 
 
@@ -215,8 +221,18 @@ When communicating with other agents, including the User, please follow these gu
             if agent.is_streaming_enabled():
                 final_response = asyncio.run(self.process_agent_streaming_response(response))
 
+            elif isinstance(response, ConversationMessage):
+                final_response = response.content[0].get('text', '') if response.content else ''
+            elif isinstance(response, dict):
+                resp_content = response.get('content', [])
+                if resp_content and isinstance(resp_content[0], dict):
+                    final_response = resp_content[0].get('text', '')
+                elif resp_content and isinstance(resp_content[0], str):
+                    final_response = resp_content[0]
+                else:
+                    final_response = str(response)
             else:
-                final_response = response.content[0].get('text', '')
+                final_response = str(response)
 
             assistant_message = TimestampedMessage(
                 role=ParticipantRole.ASSISTANT.value,

--- a/python/src/tests/agents/test_supervisor_agent.py
+++ b/python/src/tests/agents/test_supervisor_agent.py
@@ -386,3 +386,203 @@ async def test_supervisor_agent_memory_management(mock_boto3_client):
 
     response = await agent.process_request(input_text, user_id, session_id, [])
     history = await agent.storage.fetch_all_chats(user_id, session_id)
+
+
+# --- Mock agents for dict response bug fix tests ---
+
+class MockDictResponseAgent(BedrockLLMAgent):
+    """Returns dict instead of ConversationMessage (the bug scenario)."""
+    async def process_request(self, *args, **kwargs):
+        return {"role": "assistant", "content": [{"text": "Dict mock response"}]}
+
+
+class MockDictStringContentAgent(BedrockLLMAgent):
+    """Returns dict with string content items."""
+    async def process_request(self, *args, **kwargs):
+        return {"role": "assistant", "content": ["plain text response"]}
+
+
+class MockStreamingDictAgent(BedrockLLMAgent):
+    """Returns streaming response with dict final_message."""
+    def is_streaming_enabled(self):
+        return True
+
+    async def process_request(self, *args, **kwargs):
+        from agent_squad.agents import AgentStreamResponse
+        async def _stream():
+            yield AgentStreamResponse(text="chunk")
+            yield AgentStreamResponse(final_message={
+                "role": "assistant",
+                "content": [{"text": "Streamed dict response"}]
+            })
+        return _stream()
+
+
+class MockStreamingConversationAgent(BedrockLLMAgent):
+    """Returns streaming response with ConversationMessage final_message."""
+    def is_streaming_enabled(self):
+        return True
+
+    async def process_request(self, *args, **kwargs):
+        from agent_squad.agents import AgentStreamResponse
+        async def _stream():
+            yield AgentStreamResponse(text="chunk")
+            yield AgentStreamResponse(final_message=ConversationMessage(
+                role=ParticipantRole.ASSISTANT.value,
+                content=[{"text": "Streamed CM response"}]
+            ))
+        return _stream()
+
+
+# --- Tests for dict response handling (the bug fix) ---
+
+def test_send_message_dict_response(mock_boto3_client):
+    """Agent returns dict instead of ConversationMessage — no AttributeError."""
+    lead_agent = MockBedrockLLMAgent(BedrockLLMAgentOptions(
+        name="Supervisor", description="Test lead_agent"
+    ))
+    dict_agent = MockDictResponseAgent(BedrockLLMAgentOptions(
+        name="DictAgent", description="Returns dict"
+    ))
+    supervisor = SupervisorAgent(SupervisorAgentOptions(
+        name="SupervisorAgent",
+        description="Test supervisor",
+        lead_agent=lead_agent,
+        team=[dict_agent],
+        storage=mock_storage(),
+        trace=True
+    ))
+    response = supervisor.send_message(
+        agent=dict_agent,
+        content="Test message",
+        user_id="test_user",
+        session_id="test_session",
+        additional_params={}
+    )
+    assert "DictAgent: Dict mock response" in response
+
+
+def test_send_message_dict_string_content(mock_boto3_client):
+    """Dict with string content items handled correctly."""
+    lead_agent = MockBedrockLLMAgent(BedrockLLMAgentOptions(
+        name="Supervisor", description="Test lead_agent"
+    ))
+    str_agent = MockDictStringContentAgent(BedrockLLMAgentOptions(
+        name="StrAgent", description="Returns dict with strings"
+    ))
+    supervisor = SupervisorAgent(SupervisorAgentOptions(
+        name="SupervisorAgent",
+        description="Test supervisor",
+        lead_agent=lead_agent,
+        team=[str_agent],
+        storage=mock_storage(),
+        trace=True
+    ))
+    response = supervisor.send_message(
+        agent=str_agent,
+        content="Test message",
+        user_id="test_user",
+        session_id="test_session",
+        additional_params={}
+    )
+    assert "StrAgent: plain text response" in response
+
+
+def test_send_message_conversation_message_regression(mock_boto3_client):
+    """Normal ConversationMessage still works (explicit isinstance path)."""
+    lead_agent = MockBedrockLLMAgent(BedrockLLMAgentOptions(
+        name="Supervisor", description="Test lead_agent"
+    ))
+    normal_agent = MockBedrockLLMAgent(BedrockLLMAgentOptions(
+        name="NormalAgent", description="Returns ConversationMessage"
+    ))
+    supervisor = SupervisorAgent(SupervisorAgentOptions(
+        name="SupervisorAgent",
+        description="Test supervisor",
+        lead_agent=lead_agent,
+        team=[normal_agent],
+        storage=mock_storage(),
+        trace=True
+    ))
+    response = supervisor.send_message(
+        agent=normal_agent,
+        content="Test message",
+        user_id="test_user",
+        session_id="test_session",
+        additional_params={}
+    )
+    assert "NormalAgent: Mock response" in response
+
+
+def test_process_agent_streaming_response_dict_final_message(mock_boto3_client):
+    """Streaming with dict final_message handled correctly."""
+    lead_agent = MockBedrockLLMAgent(BedrockLLMAgentOptions(
+        name="Supervisor", description="Test lead_agent"
+    ))
+    streaming_agent = MockStreamingDictAgent(BedrockLLMAgentOptions(
+        name="StreamDict", description="Streaming dict agent"
+    ))
+    supervisor = SupervisorAgent(SupervisorAgentOptions(
+        name="SupervisorAgent",
+        description="Test supervisor",
+        lead_agent=lead_agent,
+        team=[streaming_agent],
+        storage=mock_storage(),
+        trace=True
+    ))
+    response = supervisor.send_message(
+        agent=streaming_agent,
+        content="Test message",
+        user_id="test_user",
+        session_id="test_session",
+        additional_params={}
+    )
+    assert "StreamDict: Streamed dict response" in response
+
+
+def test_process_agent_streaming_response_conversation_message(mock_boto3_client):
+    """Streaming with proper ConversationMessage (regression)."""
+    lead_agent = MockBedrockLLMAgent(BedrockLLMAgentOptions(
+        name="Supervisor", description="Test lead_agent"
+    ))
+    streaming_agent = MockStreamingConversationAgent(BedrockLLMAgentOptions(
+        name="StreamCM", description="Streaming CM agent"
+    ))
+    supervisor = SupervisorAgent(SupervisorAgentOptions(
+        name="SupervisorAgent",
+        description="Test supervisor",
+        lead_agent=lead_agent,
+        team=[streaming_agent],
+        storage=mock_storage(),
+        trace=True
+    ))
+    response = supervisor.send_message(
+        agent=streaming_agent,
+        content="Test message",
+        user_id="test_user",
+        session_id="test_session",
+        additional_params={}
+    )
+    assert "StreamCM: Streamed CM response" in response
+
+
+@pytest.mark.asyncio
+async def test_send_messages_with_dict_response_agent(mock_boto3_client):
+    """End-to-end through send_messages with dict-returning agent."""
+    lead_agent = MockBedrockLLMAgent(BedrockLLMAgentOptions(
+        name="Supervisor", description="Test lead_agent"
+    ))
+    dict_agent = MockDictResponseAgent(BedrockLLMAgentOptions(
+        name="DictTeamMember", description="Returns dict"
+    ))
+    supervisor = SupervisorAgent(SupervisorAgentOptions(
+        name="SupervisorAgent",
+        description="Test supervisor",
+        lead_agent=lead_agent,
+        team=[dict_agent],
+        storage=mock_storage(),
+        trace=True
+    ))
+    messages = [{"recipient": "DictTeamMember", "content": "Test message"}]
+    response = await supervisor.send_messages(messages)
+    assert "DictTeamMember: Dict mock response" in response


### PR DESCRIPTION
## Summary
- Fixed `'dict' object has no attribute 'content'` error in `SupervisorAgent.send_message()` that occurs when a team agent's `process_request()` returns a dict instead of a `ConversationMessage`
- Added type guards in both `send_message()` and `process_agent_streaming_response()` to handle both `ConversationMessage` and dict response formats
- Added 6 new tests covering dict response handling, streaming with dict final_message, and regression tests

## Details
The `send_message()` method directly accessed `response.content[0].get('text', '')` assuming `response` is always a `ConversationMessage`. However, in certain scenarios (e.g., tool use with some providers, or follow-up messages in multi-turn conversations), the response can be a plain dict with `{'role': ..., 'content': [...]}` structure.

The fix adds isinstance checks to handle both formats gracefully:
- `ConversationMessage` — access `.content` attribute as before
- `dict` — access via `.get('content', [])` 
- Other types — fall back to `str(response)`

## Tests added
Added to: `python/src/tests/agents/test_supervisor_agent.py` (6 new tests)
- **`test_send_message_dict_response`** — the bug fix test: agent returns dict, no AttributeError, extracts text correctly
- `test_send_message_dict_string_content` — dict with string content items handled
- `test_send_message_conversation_message_regression` — normal ConversationMessage still works (isinstance path)
- `test_process_agent_streaming_response_dict_final_message` — streaming with dict final_message handled
- `test_process_agent_streaming_response_conversation_message` — streaming with ConversationMessage (regression)
- `test_send_messages_with_dict_response_agent` — end-to-end through `send_messages`

## Test plan
- [x] All 18 tests pass (12 existing + 6 new) (`pytest -v`)
- [x] Dict response handling works for both dict-with-dict-content and dict-with-string-content
- [x] Streaming dict final_message handled correctly
- [x] ConversationMessage responses still work (regression tests)

Fixes #268