### PR TITLE
Fix Python streaming examples in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,14 +334,14 @@ async def main():
 
         # Stream the content
         async for chunk in response.output:
-            async for chunk in response.output:
-              if isinstance(chunk, AgentStreamResponse):
-                  print(chunk.text, end='', flush=True)
-              else:
-                  print(f"Received unexpected chunk type: {type(chunk)}", file=sys.stderr)
+            if isinstance(chunk, AgentStreamResponse):
+                print(chunk.text, end='', flush=True)
+            else:
+                print(f"Received unexpected chunk type: {type(chunk)}", file=sys.stderr)
+        print()
 
     else:
-        # Handle non-streaming response (AgentProcessingResult)
+        # Handle non-streaming response (ConversationMessage)
         print("\n** RESPONSE ** \n")
         print(f"> Agent ID: {response.metadata.agent_id}")
         print(f"> Agent Name: {response.metadata.agent_name}")

--- a/docs/src/content/docs/cookbook/examples/python-local-demo.md
+++ b/docs/src/content/docs/cookbook/examples/python-local-demo.md
@@ -34,7 +34,8 @@ from agent_squad.orchestrator import AgentSquad, AgentSquadConfig
 from agent_squad.agents import (BedrockLLMAgent,
  BedrockLLMAgentOptions,
  AgentResponse,
- AgentCallbacks)
+ AgentCallbacks,
+ AgentStreamResponse)
 from agent_squad.types import ConversationMessage, ParticipantRole
 
 orchestrator = AgentSquad(options=AgentSquadConfig(
@@ -71,11 +72,20 @@ orchestrator.add_agent(tech_agent)
 4. Implement the main logic:
 ```python
 async def handle_request(_orchestrator: AgentSquad, _user_input: str, _user_id: str, _session_id: str):
-    response: AgentResponse = await _orchestrator.route_request(_user_input, _user_id, _session_id)
+    response: AgentResponse = await _orchestrator.route_request(
+        _user_input,
+        _user_id,
+        _session_id,
+        stream_response=True,
+    )
     print("\nMetadata:")
     print(f"Selected Agent: {response.metadata.agent_name}")
     if response.streaming:
-        print('Response:', response.output.content[0]['text'])
+        print('Response:', end=' ')
+        async for chunk in response.output:
+            if isinstance(chunk, AgentStreamResponse):
+                print(chunk.text, end='', flush=True)
+        print()
     else:
         print('Response:', response.output.content[0]['text'])
 

--- a/docs/src/content/docs/general/quickstart.mdx
+++ b/docs/src/content/docs/general/quickstart.mdx
@@ -137,7 +137,8 @@ Ensure you have [requested access](https://docs.aws.amazon.com/bedrock/latest/us
     from agent_squad.agents import (BedrockLLMAgent,
      BedrockLLMAgentOptions,
      AgentResponse,
-     AgentCallbacks)
+     AgentCallbacks,
+     AgentStreamResponse)
     from agent_squad.types import ConversationMessage, ParticipantRole
 
     orchestrator = AgentSquad(options=AgentSquadConfig(
@@ -248,12 +249,21 @@ Ensure you have [requested access](https://docs.aws.amazon.com/bedrock/latest/us
   <TabItem label="Python" icon="seti:python">
     ```python
     async def handle_request(_orchestrator: AgentSquad, _user_input: str, _user_id: str, _session_id: str):
-        response: AgentResponse = await _orchestrator.route_request(_user_input, _user_id, _session_id)
+        response: AgentResponse = await _orchestrator.route_request(
+            _user_input,
+            _user_id,
+            _session_id,
+            stream_response=True,
+        )
         # Print metadata
         print("\nMetadata:")
         print(f"Selected Agent: {response.metadata.agent_name}")
         if response.streaming:
-            print('Response:', response.output.content[0]['text'])
+            print('Response:', end=' ')
+            async for chunk in response.output:
+                if isinstance(chunk, AgentStreamResponse):
+                    print(chunk.text, end='', flush=True)
+            print()
         else:
             print('Response:', response.output.content[0]['text'])
 

--- a/python/README.md
+++ b/python/README.md
@@ -159,14 +159,14 @@ async def main():
 
         # Stream the content
         async for chunk in response.output:
-            async for chunk in response.output:
-              if isinstance(chunk, AgentStreamResponse):
-                  print(chunk.text, end='', flush=True)
-              else:
-                  print(f"Received unexpected chunk type: {type(chunk)}", file=sys.stderr)
+            if isinstance(chunk, AgentStreamResponse):
+                print(chunk.text, end='', flush=True)
+            else:
+                print(f"Received unexpected chunk type: {type(chunk)}", file=sys.stderr)
+        print()
 
     else:
-        # Handle non-streaming response (AgentProcessingResult)
+        # Handle non-streaming response (ConversationMessage)
         print("\n** RESPONSE ** \n")
         print(f"> Agent ID: {response.metadata.agent_id}")
         print(f"> Agent Name: {response.metadata.agent_name}")


### PR DESCRIPTION
## Summary
- fix the Python streaming examples in the root README and Python README
- update the quickstart and python local demo docs to pass `stream_response=True`
- show streamed output by iterating over `response.output` as `AgentStreamResponse` chunks

## Why this is a local SDK/docs issue
The current Python examples show streaming usage that does not match the local `AgentSquad.route_request()` implementation in `python/src/agent_squad/orchestrator.py`. In the Python SDK, streamed chunk iteration happens when `stream_response=True` is passed and `response.output` is consumed as an async stream.

## Validation
- verified the `route_request(..., stream_response=False)` signature and streaming branch in `python/src/agent_squad/orchestrator.py`
- verified the updated examples now match that behavior

Fixes #220