### PR TITLE
fix: save intermediate tool messages to prevent missing tool_result errors

### DIFF
--- a/python/src/agent_squad/agents/bedrock_llm_agent.py
+++ b/python/src/agent_squad/agents/bedrock_llm_agent.py
@@ -102,6 +102,7 @@ class BedrockLLMAgent(Agent):
         self.system_prompt: str = ""
         self.custom_variables: TemplateVariables = {}
         self.default_max_recursions: int = 20
+        self.tool_conversation: list[ConversationMessage] = []
 
         if options.custom_system_prompt:
             self.set_system_prompt(
@@ -197,6 +198,7 @@ class BedrockLLMAgent(Agent):
         continue_with_tools = True
         llm_response = None
         accumulated_thinking = None
+        self.tool_conversation = []
 
         while continue_with_tools and max_recursions > 0:
             llm_response = await self.handle_single_response(command, agent_tracking_info)
@@ -210,13 +212,28 @@ class BedrockLLMAgent(Agent):
             conversation.append(llm_response)
 
             if any("toolUse" in content for content in llm_response.content):
+                self.tool_conversation.append(llm_response)
                 tool_response = await self._process_tool_block(llm_response, conversation, agent_tracking_info)
                 conversation.append(tool_response)
+                self.tool_conversation.append(tool_response)
                 command["messages"] = conversation_to_dict(conversation)
             else:
                 continue_with_tools = False
 
             max_recursions -= 1
+
+        # If max_recursions exhausted while tools are still in use,
+        # return a clean response without toolUse blocks to prevent
+        # saving an orphaned toolUse that would break subsequent requests.
+        if llm_response and any("toolUse" in content for content in llm_response.content):
+            cleaned_content = [c for c in llm_response.content if "toolUse" not in c]
+            if not cleaned_content:
+                cleaned_content = [{"text": "I was unable to complete the request within the allowed number of tool use attempts. Please try again or rephrase your request."}]
+            llm_response = ConversationMessage(
+                role=ParticipantRole.ASSISTANT.value,
+                content=cleaned_content,
+            )
+            conversation.append(llm_response)
 
         # Add final_thinking to agent tracking info for callbacks
         if accumulated_thinking:
@@ -237,6 +254,7 @@ class BedrockLLMAgent(Agent):
         continue_with_tools = True
         final_response = None
         accumulated_thinking = ""  # Track thinking across chunks
+        self.tool_conversation = []
 
         async def stream_generator():
             nonlocal continue_with_tools, final_response, max_recursions, accumulated_thinking
@@ -257,14 +275,29 @@ class BedrockLLMAgent(Agent):
                 conversation.append(final_response)
 
                 if any("toolUse" in content for content in final_response.content):
+                    self.tool_conversation.append(final_response)
                     tool_response = await self._process_tool_block(final_response, conversation, agent_tracking_info)
 
                     conversation.append(tool_response)
+                    self.tool_conversation.append(tool_response)
                     command["messages"] = conversation_to_dict(conversation)
                 else:
                     continue_with_tools = False
 
                 max_recursions -= 1
+
+            # If max_recursions exhausted while tools are still in use,
+            # yield a clean final response without toolUse blocks.
+            if final_response and any("toolUse" in content for content in final_response.content):
+                cleaned_content = [c for c in final_response.content if "toolUse" not in c]
+                if not cleaned_content:
+                    cleaned_content = [{"text": "I was unable to complete the request within the allowed number of tool use attempts. Please try again or rephrase your request."}]
+                final_response = ConversationMessage(
+                    role=ParticipantRole.ASSISTANT.value,
+                    content=cleaned_content,
+                )
+                conversation.append(final_response)
+                yield AgentStreamResponse(final_message=final_response)
 
             kwargs = {
                 "agent_name": self.name,

--- a/python/src/agent_squad/orchestrator.py
+++ b/python/src/agent_squad/orchestrator.py
@@ -79,7 +79,7 @@ class AgentSquad:
         } for key, agent in self.agents.items()}
 
     async def dispatch_to_agent(self, params: dict[str, Any]
-                                ) -> ConversationMessage | AsyncIterable[Any]:
+                                ) -> tuple[ConversationMessage | AsyncIterable[Any], Agent]:
         user_input = params['user_input']
         user_id = params['user_id']
         session_id = params['session_id']
@@ -90,7 +90,7 @@ class AgentSquad:
             return ConversationMessage(
                 role=ParticipantRole.ASSISTANT.value,
                 content=[{'text': "I'm sorry, but I need more information to understand your request. Could you please be more specific?"}]
-            )
+            ), None
 
         selected_agent = classifier_result.selected_agent
         agent_chat_history = await self.storage.fetch_chat(user_id, session_id, selected_agent.id)
@@ -106,7 +106,7 @@ class AgentSquad:
                                                    additional_params)
         )
 
-        return response
+        return response, selected_agent
 
     async def classify_request(self,
                              user_input: str,
@@ -145,7 +145,7 @@ class AgentSquad:
         """Process agent response and handle chat storage."""
         try:
             if classifier_result.selected_agent:
-                agent_response = await self.dispatch_to_agent({
+                agent_response, dispatched_agent = await self.dispatch_to_agent({
                     "user_input": user_input,
                     "user_id": user_id,
                     "session_id": session_id,
@@ -169,11 +169,22 @@ class AgentSquad:
                     classifier_result.selected_agent
                 )
 
+                # Save intermediate tool conversation messages (toolUse/toolResult pairs)
+                if dispatched_agent and hasattr(dispatched_agent, 'tool_conversation') and dispatched_agent.tool_conversation:
+                    await self.save_messages(
+                        dispatched_agent.tool_conversation,
+                        user_id,
+                        session_id,
+                        classifier_result.selected_agent
+                    )
+
                 final_response = None
                 if classifier_result.selected_agent.is_streaming_enabled():
                     if stream_response:
                         if isinstance(agent_response, AsyncIterable):
                             # Create an async generator function to handle the streaming
+                            selected_agent_ref = classifier_result.selected_agent
+                            dispatched_agent_ref = dispatched_agent
                             async def process_stream():
                                 full_message = None
                                 async for chunk in agent_response:
@@ -185,15 +196,26 @@ class AgentSquad:
                                         Logger.error("Invalid response type from agent. Expected AgentStreamResponse")
                                         pass
 
+                                # Save intermediate tool messages collected during streaming
+                                if dispatched_agent_ref and hasattr(dispatched_agent_ref, 'tool_conversation') and dispatched_agent_ref.tool_conversation:
+                                    await self.save_messages(
+                                        dispatched_agent_ref.tool_conversation,
+                                        user_id,
+                                        session_id,
+                                        selected_agent_ref
+                                    )
+
                                 if full_message:
                                     await self.save_message(full_message,
                                                         user_id,
                                                         session_id,
-                                                        classifier_result.selected_agent)
+                                                        selected_agent_ref)
 
 
                             final_response = process_stream()
                     else:
+                        selected_agent_ref = classifier_result.selected_agent
+                        dispatched_agent_ref = dispatched_agent
                         async def process_stream() -> ConversationMessage:
                             full_message = None
                             async for chunk in agent_response:
@@ -204,11 +226,20 @@ class AgentSquad:
                                     Logger.error("Invalid response type from agent. Expected AgentStreamResponse")
                                     pass
 
+                            # Save intermediate tool messages collected during streaming
+                            if dispatched_agent_ref and hasattr(dispatched_agent_ref, 'tool_conversation') and dispatched_agent_ref.tool_conversation:
+                                await self.save_messages(
+                                    dispatched_agent_ref.tool_conversation,
+                                    user_id,
+                                    session_id,
+                                    selected_agent_ref
+                                )
+
                             if full_message:
                                 await self.save_message(full_message,
                                                 user_id,
                                                 session_id,
-                                                classifier_result.selected_agent)
+                                                selected_agent_ref)
                             return full_message
                         final_response = await process_stream()
 

--- a/python/src/tests/agents/test_bedrock_llm_agent.py
+++ b/python/src/tests/agents/test_bedrock_llm_agent.py
@@ -832,3 +832,175 @@ def test_additional_model_request_fields(mock_boto3_client):
     # Verify topP is present when thinking is not enabled
     assert "topP" in result["inferenceConfig"]
     assert result["inferenceConfig"]["topP"] == 0.9  # Default value
+
+
+@pytest.mark.asyncio
+async def test_tool_conversation_collected_during_tool_use(bedrock_llm_agent, mock_boto3_client):
+    """Test that intermediate tool messages are collected in tool_conversation."""
+    tool_use_response = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{"toolResult": {"toolUseId": "123", "content": [{"text": "Tool output"}]}}]
+    )
+
+    bedrock_llm_agent.tool_config = {
+        "tool": [
+            AgentTool(name='test_tool', func=lambda: None, description='Test tool')
+        ],
+        "toolMaxRecursions": 5,
+        "useToolHandler": AsyncMock(return_value=tool_use_response)
+    }
+
+    mock_responses = [
+        {
+            'output': {
+                'message': {
+                    'role': 'assistant',
+                    'content': [
+                        {'text': 'Let me check'},
+                        {'toolUse': {'toolUseId': '123', 'name': 'test_tool', 'input': {}}}
+                    ]
+                }
+            }
+        },
+        {
+            'output': {
+                'message': {
+                    'role': 'assistant',
+                    'content': [{'text': 'Here is the result'}]
+                }
+            }
+        }
+    ]
+    mock_boto3_client.return_value.converse.side_effect = mock_responses
+
+    result = await bedrock_llm_agent.process_request(
+        "Test question", "test_user", "test_session", []
+    )
+
+    # Verify the final response is clean (no toolUse)
+    assert isinstance(result, ConversationMessage)
+    assert result.content[0]['text'] == 'Here is the result'
+    assert not any("toolUse" in c for c in result.content)
+
+    # Verify tool_conversation collected intermediate messages
+    assert len(bedrock_llm_agent.tool_conversation) == 2
+    # First: assistant message with toolUse
+    assert any("toolUse" in c for c in bedrock_llm_agent.tool_conversation[0].content)
+    # Second: user message with toolResult
+    assert any("toolResult" in c for c in bedrock_llm_agent.tool_conversation[1].content)
+
+
+@pytest.mark.asyncio
+async def test_max_recursions_exhaustion_returns_clean_response(bedrock_llm_agent, mock_boto3_client):
+    """Test that when max_recursions is exhausted, the response has no toolUse blocks."""
+    tool_use_response = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{"toolResult": {"toolUseId": "123", "content": [{"text": "Tool output"}]}}]
+    )
+
+    bedrock_llm_agent.tool_config = {
+        "tool": [
+            AgentTool(name='test_tool', func=lambda: None, description='Test tool')
+        ],
+        "toolMaxRecursions": 1,  # Only 1 recursion allowed
+        "useToolHandler": AsyncMock(return_value=tool_use_response)
+    }
+
+    # Model always returns toolUse - will exhaust max_recursions
+    mock_boto3_client.return_value.converse.return_value = {
+        'output': {
+            'message': {
+                'role': 'assistant',
+                'content': [
+                    {'text': 'Let me check'},
+                    {'toolUse': {'toolUseId': '123', 'name': 'test_tool', 'input': {}}}
+                ]
+            }
+        }
+    }
+
+    result = await bedrock_llm_agent.process_request(
+        "Test question", "test_user", "test_session", []
+    )
+
+    # Verify the response is clean - no toolUse blocks
+    assert isinstance(result, ConversationMessage)
+    assert not any("toolUse" in c for c in result.content)
+    # Should have text content (either original text or fallback message)
+    assert any("text" in c for c in result.content)
+
+
+@pytest.mark.asyncio
+async def test_tool_conversation_empty_when_no_tools(bedrock_llm_agent, mock_boto3_client):
+    """Test that tool_conversation is empty when no tools are used."""
+    mock_boto3_client.return_value.converse.return_value = {
+        'output': {
+            'message': {
+                'role': 'assistant',
+                'content': [{'text': 'Simple response'}]
+            }
+        }
+    }
+
+    result = await bedrock_llm_agent.process_request(
+        "Test question", "test_user", "test_session", []
+    )
+
+    assert isinstance(result, ConversationMessage)
+    assert result.content[0]['text'] == 'Simple response'
+    assert len(bedrock_llm_agent.tool_conversation) == 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_conversation_collected(bedrock_llm_agent, mock_boto3_client):
+    """Test that tool_conversation is collected during streaming with tool use."""
+    bedrock_llm_agent.streaming = True
+
+    async def mock_tool_handler(message, conversation):
+        return ConversationMessage(
+            role=ParticipantRole.USER.value,
+            content=[{"toolResult": {"toolUseId": "123", "content": [{"text": "Tool output"}]}}]
+        )
+
+    bedrock_llm_agent.tool_config = {
+        "tool": AgentTools(tools=[]),
+        "useToolHandler": mock_tool_handler
+    }
+
+    # First response with tool use
+    stream_response1 = {
+        "stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "123", "name": "test_tool"}}}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": "{\"param\":"}}}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": "\"value\"}"}}}},
+            {"contentBlockStop": {}}
+        ]
+    }
+
+    # Second response after tool use (text only)
+    stream_response2 = {
+        "stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"delta": {"text": "Final response"}}},
+            {"contentBlockStop": {}}
+        ]
+    }
+
+    mock_boto3_client.return_value.converse_stream.side_effect = [stream_response1, stream_response2]
+
+    result = await bedrock_llm_agent.process_request(
+        "Test with tool", "test_user", "test_session", []
+    )
+
+    # Consume the stream
+    chunks = []
+    async for chunk in result:
+        chunks.append(chunk)
+
+    # Verify tool_conversation was populated during streaming
+    assert len(bedrock_llm_agent.tool_conversation) == 2
+    # First: assistant message with toolUse
+    assert any("toolUse" in c for c in bedrock_llm_agent.tool_conversation[0].content)
+    # Second: user message with toolResult
+    assert any("toolResult" in c for c in bedrock_llm_agent.tool_conversation[1].content)

--- a/python/src/tests/test_orchestrator.py
+++ b/python/src/tests/test_orchestrator.py
@@ -146,7 +146,7 @@ async def test_dispatch_to_agent_success(orchestrator, mock_agent):
     )
     mock_agent.process_request.return_value = expected_response
 
-    response = await orchestrator.dispatch_to_agent({
+    response, agent = await orchestrator.dispatch_to_agent({
         "user_input": "test",
         "user_id": "user1",
         "session_id": "session1",
@@ -155,12 +155,13 @@ async def test_dispatch_to_agent_success(orchestrator, mock_agent):
     })
 
     assert response == expected_response
+    assert agent == mock_agent
 
 @pytest.mark.asyncio
 async def test_dispatch_to_agent_no_agent(orchestrator):
     classifier_result = ClassifierResult(selected_agent=None, confidence=0)
 
-    response = await orchestrator.dispatch_to_agent({
+    response, agent = await orchestrator.dispatch_to_agent({
         "user_input": "test",
         "user_id": "user1",
         "session_id": "session1",
@@ -170,6 +171,7 @@ async def test_dispatch_to_agent_no_agent(orchestrator):
 
     assert isinstance(response, ConversationMessage)
     assert "more information" in response.content[0].get('text')
+    assert agent is None
 
 # Test streaming functionality
 @pytest.mark.asyncio
@@ -335,6 +337,79 @@ def test_create_metadata_no_agent(orchestrator):
     assert metadata.agent_name == "No Agent"
     assert "error_type" in metadata.additional_params
     assert metadata.additional_params["error_type"] == "classification_failed"
+
+# Test intermediate tool messages are saved
+@pytest.mark.asyncio
+async def test_agent_process_request_saves_tool_conversation(orchestrator, mock_agent):
+    """Test that intermediate tool messages (toolUse/toolResult) are saved to storage."""
+    classifier_result = ClassifierResult(selected_agent=mock_agent, confidence=0.9)
+
+    # Set up tool_conversation on the mock agent
+    tool_use_msg = ConversationMessage(
+        role=ParticipantRole.ASSISTANT.value,
+        content=[{"toolUse": {"toolUseId": "123", "name": "test_tool", "input": {}}}]
+    )
+    tool_result_msg = ConversationMessage(
+        role=ParticipantRole.USER.value,
+        content=[{"toolResult": {"toolUseId": "123", "content": [{"text": "Tool output"}]}}]
+    )
+    mock_agent.tool_conversation = [tool_use_msg, tool_result_msg]
+
+    final_response = ConversationMessage(
+        role=ParticipantRole.ASSISTANT.value,
+        content=[{"text": "Final answer based on tool output"}]
+    )
+    mock_agent.process_request.return_value = final_response
+
+    response = await orchestrator.agent_process_request(
+        "test input", "user1", "session1", classifier_result
+    )
+
+    # Verify storage was called for:
+    # 1. User message
+    # 2. Tool use message (from tool_conversation)
+    # 3. Tool result message (from tool_conversation)
+    # 4. Final assistant response
+    assert orchestrator.storage.save_chat_message.call_count == 4
+
+    # Check the saved messages in order
+    calls = orchestrator.storage.save_chat_message.call_args_list
+    # First: user message
+    assert calls[0][0][3].role == ParticipantRole.USER.value
+    assert calls[0][0][3].content[0]['text'] == 'test input'
+    # Second: assistant toolUse
+    assert calls[1][0][3].role == ParticipantRole.ASSISTANT.value
+    assert "toolUse" in calls[1][0][3].content[0]
+    # Third: user toolResult
+    assert calls[2][0][3].role == ParticipantRole.USER.value
+    assert "toolResult" in calls[2][0][3].content[0]
+    # Fourth: final assistant response
+    assert calls[3][0][3].role == ParticipantRole.ASSISTANT.value
+    assert calls[3][0][3].content[0]['text'] == 'Final answer based on tool output'
+
+
+@pytest.mark.asyncio
+async def test_agent_process_request_no_tool_conversation(orchestrator, mock_agent):
+    """Test that when no tools are used, only user message and response are saved."""
+    classifier_result = ClassifierResult(selected_agent=mock_agent, confidence=0.9)
+
+    # No tool_conversation attribute
+    if hasattr(mock_agent, 'tool_conversation'):
+        delattr(mock_agent, 'tool_conversation')
+
+    final_response = ConversationMessage(
+        role=ParticipantRole.ASSISTANT.value,
+        content=[{"text": "Simple response"}]
+    )
+    mock_agent.process_request.return_value = final_response
+
+    response = await orchestrator.agent_process_request(
+        "test input", "user1", "session1", classifier_result
+    )
+
+    # Only user message + final response = 2 saves
+    assert orchestrator.storage.save_chat_message.call_count == 2
+
 
 # Test fallback functionality
 def test_get_fallback_result(orchestrator, mock_agent):


### PR DESCRIPTION
## Summary

Fixes #396

When `BedrockLLMAgent` uses tools, the intermediate `toolUse`/`toolResult` conversation messages were only kept in a local list and never persisted to storage. This caused subsequent requests to fail with Bedrock validation errors about missing `tool_result` blocks.

- `BedrockLLMAgent` now collects intermediate tool messages in `tool_conversation` during both single and streaming responses
- `Orchestrator` saves these intermediate messages to storage alongside user input and final response
- When `max_recursions` is exhausted, `toolUse` blocks are stripped from the response to prevent saving orphaned `toolUse` without `toolResult`

## Test plan

- [x] Added unit tests for `BedrockLLMAgent` tool message collection (`test_bedrock_llm_agent.py`)
- [x] Added unit tests for `Orchestrator` intermediate message persistence (`test_orchestrator.py`)
- [ ] Manual test: verify multi-turn conversations with tool-using `BedrockLLMAgent` + `DynamoDBStorage` no longer raise `ValidationException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)