### PR TITLE
fix: pass MAX_MESSAGE_PAIRS_PER_AGENT to streaming conversation save

### DIFF
--- a/typescript/src/orchestrator.ts
+++ b/typescript/src/orchestrator.ts
@@ -536,7 +536,8 @@ export class AgentSquad {
             this.storage,
             userId,
             sessionId,
-            agent.id
+            agent.id,
+            this.config.MAX_MESSAGE_PAIRS_PER_AGENT
           );
         }
       } else {


### PR DESCRIPTION
Fixes #365

## Problem

The processStreamInBackground method in orchestrator.ts was calling saveConversationExchange without the maxHistorySize parameter. Streaming responses ignored MAX_MESSAGE_PAIRS_PER_AGENT, causing unbounded conversation history growth.

## Solution

Added the missing this.config.MAX_MESSAGE_PAIRS_PER_AGENT parameter to saveConversationExchange inside processStreamInBackground, matching the non-streaming code path.

## Testing

The fix is a one-line addition aligning the streaming code path with the already-correct non-streaming path.