### PR TITLE
fix: assign comprehend_client correctly in ComprehendFilterAgent and fix on_llm_start docstring

### DIFF
--- a/python/src/agent_squad/agents/agent.py
+++ b/python/src/agent_squad/agents/agent.py
@@ -146,9 +146,8 @@ class AgentCallbacks:
 
         Parameters:
             self: The instance of the callback handler class.
-            agent_name: Name of the agent that is starting.
+            name: Name of the llm that is starting.
             payload_input: Dictionary containing the agent's input.
-            messages: List of message dictionaries representing the conversation history.
             run_id: Unique identifier for this specific agent run.
             tags: Optional list of string tags associated with this agent run.
             metadata: Optional dictionary containing additional metadata about the run.

--- a/python/src/agent_squad/agents/comprehend_filter_agent.py
+++ b/python/src/agent_squad/agents/comprehend_filter_agent.py
@@ -31,12 +31,12 @@ class ComprehendFilterAgent(Agent):
             self.comprehend_client = options.client
         else:
             if options.region:
-                self.client = boto3.client(
+                self.comprehend_client = boto3.client(
                     'comprehend',
                     region_name=options.region or os.environ.get('AWS_REGION')
                 )
             else:
-                self.client = boto3.client('comprehend')
+                self.comprehend_client = boto3.client('comprehend')
 
         self.custom_checks: list[CheckFunction] = []
 


### PR DESCRIPTION
Fixes #359, fixes #360

## Problem 1 (fixes #359)

When `ComprehendFilterAgent` is initialized without a `client` option, the constructor assigned the boto3 client to `self.client` instead of `self.comprehend_client`. All detection methods (`detect_sentiment`, `detect_pii_entities`, `detect_toxic_content`) reference `self.comprehend_client`, so they raised `AttributeError: 'ComprehendFilterAgent' object has no attribute 'comprehend_client'` on the first request.

## Solution 1

Changed `self.client = boto3.client(...)` to `self.comprehend_client = boto3.client(...)` in both branches of the else block, consistent with the existing `options.client` path.

## Problem 2 (fixes #360)

The `on_llm_start` docstring listed two incorrect parameters: `agent_name` (actual parameter is `name`) and `messages` (not a parameter of this method at all).

## Solution 2

Updated the docstring to match the actual method signature: replaced `agent_name` with `name` and removed the non-existent `messages` entry.