### PR TITLE
fix: update agent-squad dependency versions in examples to ^1.0.0

### DIFF
--- a/examples/chat-demo-app/package.json
+++ b/examples/chat-demo-app/package.json
@@ -34,7 +34,7 @@
     "constructs": "^10.0.0",
     "esbuild": "^0.24.0",
     "i": "^0.3.7",
-    "agent-squad": "^0.0.17",
+    "agent-squad": "^1.0.0",
     "natural": "^7.1.0",
     "npm": "^10.8.1",
     "source-map-support": "^0.5.21",

--- a/examples/ecommerce-support-simulator/package.json
+++ b/examples/ecommerce-support-simulator/package.json
@@ -32,7 +32,7 @@
     "axios": "^1.13.5",
     "constructs": "^10.0.0",
     "esbuild": "^0.24.0",
-    "agent-squad": "^0.0.14",
+    "agent-squad": "^1.0.0",
     "source-map-support": "^0.5.21"
   }
 }

--- a/examples/local-demo/package.json
+++ b/examples/local-demo/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "agent-squad": "^0.0.17"
+    "agent-squad": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Issue Link (REQUIRED)
Fixes #456

## Summary
### Changes
Updated `agent-squad` dependency version constraints in three example `package.json` files from outdated `^0.0.14` / `^0.0.17` to `^1.0.0`:
- `examples/chat-demo-app/package.json`: `^0.0.17` → `^1.0.0`
- `examples/local-demo/package.json`: `^0.0.17` → `^1.0.0`
- `examples/ecommerce-support-simulator/package.json`: `^0.0.14` → `^1.0.0`

### User experience
**Before**: Running `npm install` in the example directories fails with:
```
npm error 404 Not Found - GET https://registry.npmjs.org/agent-squad/-/agent-squad-0.0.17.tgz - Not found
```

**After**: `npm install` resolves the current `agent-squad@1.0.1` package from npm without errors.

## Checklist
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] I have linked this PR to an existing issue (required)

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.