### PR TITLE
docs: add missing Python snippets to logging guide

### DIFF
--- a/docs/src/content/docs/cookbook/monitoring/logging.mdx
+++ b/docs/src/content/docs/cookbook/monitoring/logging.mdx
@@ -33,7 +33,14 @@ export interface OrchestratorOptions {
   </TabItem>
   <TabItem label="Python" icon="seti:python">
 ```python
-// TODO: Add python code here
+class AgentSquad:
+    def __init__(self,
+                 options: AgentSquadConfig | None = None,
+                 storage: ChatStorage | None = None,
+                 classifier: Classifier | None = None,
+                 logger: Logger | None = None,
+                 default_agent: Agent | None = None):
+        ...
 ```
   </TabItem>
 </Tabs>
@@ -56,8 +63,8 @@ npm install @aws-lambda-powertools/logger
 
   </TabItem>
   <TabItem label="Python" icon="seti:python">
-```python
-// TODO: Add python code here
+```bash
+pip install aws-lambda-powertools
 ```
   </TabItem>
 </Tabs>
@@ -81,7 +88,12 @@ const logger = new Logger({
   </TabItem>
   <TabItem label="Python" icon="seti:python">
 ```python
-// TODO: Add python code here
+from aws_lambda_powertools import Logger
+
+logger = Logger(
+    service="MyOrchestratorService",
+    level="INFO"
+)
 ```
   </TabItem>
 </Tabs>
@@ -109,7 +121,20 @@ const orchestrator = new AgentSquad({
   </TabItem>
   <TabItem label="Python" icon="seti:python">
 ```python
-// TODO: Add python code here
+from agent_squad.orchestrator import AgentSquad
+from agent_squad.types import AgentSquadConfig
+
+orchestrator = AgentSquad(
+    storage=storage,
+    options=AgentSquadConfig(
+        LOG_AGENT_CHAT=True,
+        LOG_CLASSIFIER_CHAT=True,
+        LOG_CLASSIFIER_RAW_OUTPUT=True,
+        LOG_CLASSIFIER_OUTPUT=True,
+        LOG_EXECUTION_TIMES=True,
+    ),
+    logger=logger,
+)
 ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Issue Link (REQUIRED)
Fixes #439

## Summary
### Changes
The logging cookbook page (`docs/src/content/docs/cookbook/monitoring/logging.mdx`) had four Python tabs containing `// TODO: Add python code here` placeholders. This fills all four with Python equivalents of the existing TypeScript snippets:

- **OrchestratorOptions** → the `AgentSquad.__init__` constructor signature (Python's equivalent of the TS options interface)
- **Install command** → `pip install aws-lambda-powertools`
- **Logger init** → `from aws_lambda_powertools import Logger` / `Logger(service=..., level="INFO")`
- **Orchestrator creation** → `AgentSquad(storage=..., options=AgentSquadConfig(...), logger=logger)`

Snippets were verified against the Python source: the constructor signature matches `python/src/agent_squad/orchestrator.py`, the `LOG_*` flags match `AgentSquadConfig` in `python/src/agent_squad/types/types.py`, and import paths are correct.

### User experience
Before: every Python tab on the logging guide showed a `// TODO` placeholder with no working example. After: each tab shows a correct, copy-pasteable Python snippet mirroring the TypeScript side, restoring the repo's documented TS/Python feature parity.

## Checklist
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] I have linked this PR to an existing issue (required)