### PR TITLE
fix: handle tool execution errors in AgentTools._process_tool

### DIFF
--- a/python/src/agent_squad/utils/tool.py
+++ b/python/src/agent_squad/utils/tool.py
@@ -304,11 +304,13 @@ class AgentTools:
         return None
 
     async def _process_tool(self, tool_name, input_data):
-        try:
-            tool = next(tool for tool in self.tools if tool.name == tool_name)
-            return await tool.func(**input_data)
-        except StopIteration:
+        tool = next((tool for tool in self.tools if tool.name == tool_name), None)
+        if tool is None:
             return f"Tool '{tool_name}' not found"
+        try:
+            return await tool.func(**input_data)
+        except Exception as e:
+            return f"Error processing tool '{tool_name}': {e}"
 
     def to_claude_format(self) -> list[dict[str, Any]]:
         """Convert all tools to Claude format"""

--- a/python/src/tests/utils/test_tool.py
+++ b/python/src/tests/utils/test_tool.py
@@ -473,14 +473,25 @@ def test_tool_with_properties():
 
 @pytest.mark.asyncio
 async def test_tool_not_found():
-    try:
-        tools = AgentTools([AgentTool(
-            name="weather",
-            func=fetch_weather_data
-        )])
-        await tools._process_tool("test", {'test':'value'})
-    except Exception as e:
-        assert str(e) == f"Tool weather not found"
+    tools = AgentTools([AgentTool(
+        name="weather",
+        func=fetch_weather_data
+    )])
+    result = await tools._process_tool("test", {'test': 'value'})
+    assert result == "Tool 'test' not found"
+
+
+@pytest.mark.asyncio
+async def test_tool_processing_error():
+    async def failing_tool(value: str):
+        raise ValueError("boom")
+
+    tools = AgentTools([AgentTool(
+        name="failing",
+        func=failing_tool
+    )])
+    result = await tools._process_tool("failing", {'value': 'x'})
+    assert result == "Error processing tool 'failing': boom"
 
 
 def test_get_tool_use_block():


### PR DESCRIPTION
## Issue Link (REQUIRED)
Fixes #250

## Summary
### Changes
`AgentTools._process_tool` only caught `StopIteration` (the missing-tool case) and let any exception raised by the tool's own `func` propagate, crashing the whole request flow. This brings the Python behavior in line with the TypeScript `processTool`, which already returns an error string when a tool errors:

- Missing tool → `Tool '<name>' not found` (unchanged behavior, rewritten with `next(..., None)` so a `StopIteration` raised *inside* a tool can't be mislabeled as "not found").
- Tool raises during execution → `Error processing tool '<name>': <error>` (previously uncaught).

Also fixed the existing `test_tool_not_found`, which asserted inside an `except` block that never executed (the function returns rather than raises), and added `test_tool_processing_error` for the new error path.

### User experience
Before: a tool that raised an exception (or a prompt referencing a mistyped tool name) surfaced as an unhandled error that aborted `route_request`. After: the error is returned as a tool result string, so the agent loop can see it and respond gracefully instead of crashing.

## Checklist
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] I have linked this PR to an existing issue (required)