### PR TITLE
fix: set comprehend_client when ComprehendFilterAgent creates a default client

### DIFF
--- a/python/src/agent_squad/agents/comprehend_filter_agent.py
+++ b/python/src/agent_squad/agents/comprehend_filter_agent.py
@@ -31,12 +31,12 @@ class ComprehendFilterAgent(Agent):
             self.comprehend_client = options.client
         else:
             if options.region:
-                self.client = boto3.client(
+                self.comprehend_client = boto3.client(
                     'comprehend',
                     region_name=options.region or os.environ.get('AWS_REGION')
                 )
             else:
-                self.client = boto3.client('comprehend')
+                self.comprehend_client = boto3.client('comprehend')
 
         self.custom_checks: list[CheckFunction] = []
 

--- a/python/src/tests/agents/test_comprehend_agent.py
+++ b/python/src/tests/agents/test_comprehend_agent.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from typing import Dict, Any
 
 from agent_squad.types import ConversationMessage, ParticipantRole
@@ -215,6 +215,23 @@ class TestComprehendFilterAgent(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(agent.sentiment_threshold, 0.5)
         self.assertEqual(agent.toxicity_threshold, 0.8)
+
+    @patch('agent_squad.agents.comprehend_filter_agent.boto3.client')
+    async def test_default_client_creation_without_client(self, mock_boto_client):
+        """When no client is provided, a comprehend client should be created."""
+        created_client = Mock()
+        mock_boto_client.return_value = created_client
+
+        agent = ComprehendFilterAgent(
+            ComprehendFilterAgentOptions(
+                name="Test Filter Agent",
+                description="Test agent for filtering content",
+                client=None,
+            )
+        )
+
+        mock_boto_client.assert_called_once_with('comprehend')
+        self.assertEqual(agent.comprehend_client, created_client)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Issue Link (REQUIRED)
Fixes #359

## Summary
### Changes
When no `client` is passed to `ComprehendFilterAgent`, the constructor created the boto3 Comprehend client but assigned it to `self.client` instead of `self.comprehend_client`. Since `detect_sentiment` / `detect_pii_entities` / `detect_toxic_content` all use `self.comprehend_client`, calling `process_request` raised:
`'ComprehendFilterAgent' object has no attribute 'comprehend_client'`.

Assign the default-created client to `self.comprehend_client` so the agent works without an explicitly provided client. Added a regression test that patches `boto3.client` and asserts `comprehend_client` is set when `client=None`.

### User experience
Before: constructing a `ComprehendFilterAgent` without a `client` (the documented default) crashed on the first request. After: the agent creates its own Comprehend client and runs normally.

## Checklist
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] I have linked this PR to an existing issue (required)