### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ if (response.streaming == true) {
 
 ```bash
 # Optional: Set up a virtual environment
+
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/2fastlabs-agent-squad)
+
 python -m venv venv
 source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 pip install agent-squad[aws]


### PR DESCRIPTION
Hi! 👋 **agent-squad** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/2fastlabs-agent-squad

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building agent-squad! 🙏