### PR TITLE
fix: preserve custom name/description on SupervisorAgent

### DIFF
--- a/python/src/agent_squad/agents/supervisor_agent.py
+++ b/python/src/agent_squad/agents/supervisor_agent.py
@@ -66,8 +66,8 @@ class SupervisorAgent(Agent):
 
     def __init__(self, options: SupervisorAgentOptions):
         options.validate()
-        options.name = options.lead_agent.name
-        options.description = options.lead_agent.description
+        options.name = options.name or options.lead_agent.name
+        options.description = options.description or options.lead_agent.description
         super().__init__(options)
 
         self.lead_agent: 'Union[AnthropicAgent, BedrockLLMAgent]' = options.lead_agent

--- a/python/src/tests/agents/test_supervisor_agent.py
+++ b/python/src/tests/agents/test_supervisor_agent.py
@@ -103,6 +103,24 @@ async def test_supervisor_agent_initialization(mock_boto3_client):
     assert isinstance(agent.supervisor_tools, AgentTools)
 
 @pytest.mark.asyncio
+async def test_supervisor_agent_preserves_custom_name_and_description(mock_boto3_client):
+    """Custom name/description on SupervisorAgentOptions must not be overwritten by lead_agent values"""
+    lead_agent = MockBedrockLLMAgent(BedrockLLMAgentOptions(
+        name="Lead Agent Name",
+        description="Lead Agent Description"
+    ))
+
+    agent = SupervisorAgent(SupervisorAgentOptions(
+        name="Custom Supervisor Name",
+        description="Custom Supervisor Description",
+        lead_agent=lead_agent,
+        team=[]
+    ))
+
+    assert agent.name == "Custom Supervisor Name"
+    assert agent.description == "Custom Supervisor Description"
+
+@pytest.mark.asyncio
 async def test_supervisor_agent_validation(mock_boto3_client):
     """Test SupervisorAgent validation"""
     with pytest.raises(ValueError, match="Supervisor must be BedrockLLMAgent or AnthropicAgent"):

--- a/typescript/src/agents/supervisorAgent.ts
+++ b/typescript/src/agents/supervisorAgent.ts
@@ -57,8 +57,8 @@ export class SupervisorAgent extends Agent {
 
     super({
       ...options,
-      name: options.leadAgent.name,
-      description: options.leadAgent.description,
+      name: options.name ?? options.leadAgent.name,
+      description: options.description ?? options.leadAgent.description,
     });
 
     this.leadAgent = options.leadAgent;

--- a/typescript/src/agents/supervisorAgent.ts
+++ b/typescript/src/agents/supervisorAgent.ts
@@ -57,8 +57,8 @@ export class SupervisorAgent extends Agent {
 
     super({
       ...options,
-      name: options.name ?? options.leadAgent.name,
-      description: options.description ?? options.leadAgent.description,
+      name: options.name || options.leadAgent.name,
+      description: options.description || options.leadAgent.description,
     });
 
     this.leadAgent = options.leadAgent;

--- a/typescript/tests/agents/SupervisorAgent.test.ts
+++ b/typescript/tests/agents/SupervisorAgent.test.ts
@@ -1,0 +1,61 @@
+import { SupervisorAgent } from "../../src/agents/supervisorAgent";
+import { BedrockLLMAgent } from "../../src/agents/bedrockLLMAgent";
+import { ConversationMessage, ParticipantRole } from "../../src/types";
+
+class MockBedrockLLMAgent extends BedrockLLMAgent {
+  constructor(config: { name: string; description: string }) {
+    super(config);
+  }
+
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  async processRequest(
+    inputText: string,
+    userId: string,
+    sessionId: string,
+    chatHistory: ConversationMessage[],
+    additionalParams?: Record<string, string>
+  ): Promise<ConversationMessage | AsyncIterable<any>> {
+    return {
+      role: ParticipantRole.ASSISTANT,
+      content: [{ text: "Mock response" }],
+    };
+  }
+}
+
+describe("SupervisorAgent", () => {
+  describe("constructor", () => {
+    it("should preserve custom name and description instead of overwriting them with the lead agent's values", () => {
+      const leadAgent = new MockBedrockLLMAgent({
+        name: "Lead Agent Name",
+        description: "Lead Agent Description",
+      });
+
+      const supervisor = new SupervisorAgent({
+        name: "Custom Supervisor Name",
+        description: "Custom Supervisor Description",
+        leadAgent,
+        team: [],
+      });
+
+      expect(supervisor.name).toBe("Custom Supervisor Name");
+      expect(supervisor.description).toBe("Custom Supervisor Description");
+    });
+
+    it("should fall back to the lead agent's name and description when none are provided", () => {
+      const leadAgent = new MockBedrockLLMAgent({
+        name: "Lead Agent Name",
+        description: "Lead Agent Description",
+      });
+
+      const supervisor = new SupervisorAgent({
+        name: "",
+        description: "",
+        leadAgent,
+        team: [],
+      });
+
+      expect(supervisor.name).toBe("Lead Agent Name");
+      expect(supervisor.description).toBe("Lead Agent Description");
+    });
+  });
+});


### PR DESCRIPTION
## Issue Link (REQUIRED)
Fixes #254

## Summary
### Changes
`SupervisorAgent` unconditionally overwrote `options.name` and `options.description` with the lead agent's values, even when the caller supplied their own. Changed both Python and TypeScript implementations to use the caller-provided values and fall back to the lead agent's values only when none were given.

**Python** (`python/src/agent_squad/agents/supervisor_agent.py`):
```python
# before
options.name = options.lead_agent.name
options.description = options.lead_agent.description

# after
options.name = options.name or options.lead_agent.name
options.description = options.description or options.lead_agent.description
```

**TypeScript** (`typescript/src/agents/supervisorAgent.ts`):
```typescript
// before
super({ ...options, name: options.leadAgent.name, description: options.leadAgent.description });

// after
super({ ...options, name: options.name ?? options.leadAgent.name, description: options.description ?? options.leadAgent.description });
```

### User experience
Before: passing `name="My Supervisor"` to `SupervisorAgentOptions` had no effect — the name was replaced by the lead agent's name.

After: user-supplied `name`/`description` are preserved; the lead agent's values are used only as defaults when none are provided.

## Checklist
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] I have linked this PR to an existing issue (required)

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.