### PR TITLE
fix: address P2 bugs from PR #543 review (percent-encoding, app-only routing, URL join)

### DIFF
--- a/swift/Sources/AgentSquad/Core/Tooling/AggregateToolProvider.swift
+++ b/swift/Sources/AgentSquad/Core/Tooling/AggregateToolProvider.swift
@@ -4,7 +4,8 @@ import Foundation
 /// and merges first-wins by name; `call` routes to the owning provider.
 public actor AggregateToolProvider: ToolProvider {
     private let providers: [any ToolProvider]
-    private var routing: [String: Int] = [:]   // tool name → index into `providers`
+    /// `nil` until the first `listTools()` call; an empty dict means no tools were advertised.
+    private var routing: [String: Int]?   // tool name → index into `providers`
 
     public init(_ providers: [any ToolProvider]) {
         self.providers = providers
@@ -41,8 +42,21 @@ public actor AggregateToolProvider: ToolProvider {
 
     public func call(_ name: String, arguments: JSONValue) async throws -> ToolResult {
         // Build the routing map on first use (an agent normally calls listTools first anyway).
-        if routing.isEmpty { _ = try await listTools() }
-        guard let index = routing[name] else { return .failure("Tool not found: \(name)") }
-        return try await providers[index].call(name, arguments: arguments)
+        if routing == nil { _ = try await listTools() }
+        if let index = routing?[name] {
+            return try await providers[index].call(name, arguments: arguments)
+        }
+        // App-only tools are excluded from listTools() and therefore absent from routing.
+        // ToolKit.call() can still service them directly, so try each provider in order.
+        // Stop at the first result that isn't a "Tool not found:" sentinel.
+        for provider in providers {
+            let result = try await provider.call(name, arguments: arguments)
+            let isNotFound = result.isError &&
+                result.content?.first.flatMap {
+                    if case .text(let t) = $0 { return t } else { return nil }
+                }?.hasPrefix("Tool not found:") == true
+            if !isNotFound { return result }
+        }
+        return .failure("Tool not found: \(name)")
     }
 }

--- a/swift/Sources/AgentSquad/Core/Tooling/HTTPToolGroup.swift
+++ b/swift/Sources/AgentSquad/Core/Tooling/HTTPToolGroup.swift
@@ -127,10 +127,18 @@ public struct HTTPToolGroup: Sendable {
             name: name, description: description, inputSchema: arguments.objectSchema(),
             ui: ui, visibility: visibility, outputSchema: outputSchema,
             spec: HTTPToolSpec(
-                method: method, url: baseURL + path,
+                method: method, url: joinURL(path: path),
                 headers: headers, secrets: secrets, hostArguments: hostArguments,
                 body: body, response: response ?? self.response, timeout: timeout, invoker: invoker
             )
         )
+    }
+
+    /// Join `baseURL` and `path`, normalizing trailing/leading slashes so the result always has
+    /// exactly one separator (e.g. avoids `"https://api.test//users"` or `"https://api.testusers"`).
+    private func joinURL(path: String) -> String {
+        let base = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
+        let sep = path.hasPrefix("/") ? "" : "/"
+        return base + sep + path
     }
 }

--- a/swift/Sources/AgentSquad/Core/Tooling/HTTPToolSpec.swift
+++ b/swift/Sources/AgentSquad/Core/Tooling/HTTPToolSpec.swift
@@ -175,7 +175,13 @@ public struct HTTPToolSpec: Sendable {
         var urlString = url
         for key in Self.templateKeys(in: url) {
             let raw = args[key].map(Self.scalarString) ?? ""
-            let encoded = raw.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? raw
+            // Use the correct character set depending on whether the placeholder is in the query
+            // string or the path. Path-component encoding forbids '/' (prevents segment injection);
+            // query-value encoding forbids '&', '=', '+', '#' (prevents parameter injection).
+            let charset: CharacterSet = Self.isInQueryPart(url, key: key)
+                ? Self.urlQueryValueAllowed
+                : .urlPathComponentAllowed
+            let encoded = raw.addingPercentEncoding(withAllowedCharacters: charset) ?? raw
             urlString = urlString.replacingOccurrences(of: "{\(key)}", with: encoded)
             args.removeValue(forKey: key)
         }
@@ -237,6 +243,23 @@ public struct HTTPToolSpec: Sendable {
             return String(decoding: data, as: UTF8.self)
         }
     }
+
+    /// Returns true when the `{key}` placeholder appears after the first `?` in the URL template,
+    /// meaning its value will land in the query string rather than the path.
+    static func isInQueryPart(_ url: String, key: String) -> Bool {
+        let placeholder = "{\(key)}"
+        guard let placeholderRange = url.range(of: placeholder),
+              let questionMark = url.firstIndex(of: "?") else { return false }
+        return placeholderRange.lowerBound > questionMark
+    }
+
+    /// Character set safe for percent-encoding a query-item value. Starts from `.urlQueryAllowed`
+    /// and removes delimiter characters that would otherwise split or corrupt the query string.
+    private static let urlQueryValueAllowed: CharacterSet = {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "&=+#")
+        return allowed
+    }()
 
     /// Merge host arguments into a call's arguments (host values win). Injects all of them, not just
     /// schema-declared keys (unlike MCP) — a host value may feed a `{token}` path slot or query item.

--- a/swift/Tests/AgentSquadTests/AggregateToolProviderTests.swift
+++ b/swift/Tests/AgentSquadTests/AggregateToolProviderTests.swift
@@ -48,4 +48,34 @@ import Testing
         let result = try await AggregateToolProvider([a]).call("solo", arguments: .object([:]))
         #expect(result.structuredContent == ["ok": true])
     }
+
+    @Test func appOnlyToolIsCallableThroughAggregate() async throws {
+        // An app-only tool is excluded from listTools() but must still be callable via call().
+        let kit = ToolKit([
+            .local(name: "visible", description: "") { _ in ToolResult() },
+            .local(name: "app_only", description: "", visibility: .app) { _ in
+                ToolResult(structuredContent: ["ran": true])
+            },
+        ])
+        let aggregate = AggregateToolProvider([kit])
+
+        // listTools() must not advertise the app-only tool to the model.
+        let listed = try await aggregate.listTools().map(\.name)
+        #expect(listed == ["visible"])
+
+        // call() must still reach the app-only tool.
+        let result = try await aggregate.call("app_only", arguments: .object([:]))
+        #expect(result.isError == false)
+        #expect(result.structuredContent == ["ran": true])
+    }
+
+    @Test func emptyProvidersHasStableRoutingState() async throws {
+        // An aggregate over zero-tool providers must not re-call listTools() on every call().
+        let empty = StubToolProvider(tools: [], results: [:])
+        let aggregate = AggregateToolProvider([empty])
+        _ = try await aggregate.listTools()
+        // Calling an unknown tool after listTools() must return failure without re-listing.
+        let result = try await aggregate.call("ghost", arguments: .object([:]))
+        #expect(result.isError)
+    }
 }

--- a/swift/Tests/AgentSquadTests/HTTPToolTests.swift
+++ b/swift/Tests/AgentSquadTests/HTTPToolTests.swift
@@ -45,6 +45,27 @@ private func queryValue(_ request: URLRequest?, _ name: String) -> String? {
         #expect(queryValue(request, "live") == "true")
     }
 
+    @Test func pathPlaceholderEncodesSlash() throws {
+        // A value containing '/' must not create extra path segments.
+        let spec = HTTPToolSpec(method: .get, url: "https://api.test/users/{id}/profile")
+        let request = try spec.makeRequest(arguments: ["id": "foo/bar"])
+        #expect(request.url?.absoluteString.contains("/users/foo%2Fbar/profile") == true)
+    }
+
+    @Test func queryPlaceholderEncodesDelimiters() throws {
+        // A value containing '&' or '=' must not create extra query parameters.
+        let spec = HTTPToolSpec(method: .get, url: "https://api.test/search?q={query}")
+        let request = try spec.makeRequest(arguments: ["query": "a&b=c"])
+        let urlString = request.url?.absoluteString ?? ""
+        // The '&' and '=' must be percent-encoded so they don't split the query string.
+        #expect(urlString.contains("a%26b%3Dc") == true)
+        // Only one query item: 'q'
+        let components = URLComponents(string: urlString)
+        #expect(components?.queryItems?.count == 1)
+        #expect(components?.queryItems?.first?.name == "q")
+        #expect(components?.queryItems?.first?.value == "a&b=c")
+    }
+
     @Test func postSendsJSONBodyWithContentType() throws {
         let spec = HTTPToolSpec(method: .post, url: "https://api.test/bets")
         let request = try spec.makeRequest(arguments: ["stake": 10, "selection": "home"])
@@ -64,6 +85,26 @@ private func queryValue(_ request: URLRequest?, _ name: String) -> String? {
         let request = try spec.makeRequest(arguments: .object([:]))
         #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer tok")
+    }
+
+    // MARK: - HTTPToolGroup URL joining
+
+    @Test func groupNormalizesDoubleSlash() async throws {
+        // baseURL trailing '/' + path leading '/' must not produce a double slash.
+        let invoker = MockInvoker(status: 200, body: "{}")
+        let group = HTTPToolGroup(baseURL: "https://api.test/", invoker: invoker)
+        let tool = group.get("users", "/users", "")
+        _ = try await tool.run(.object([:]))
+        #expect(invoker.request?.url?.absoluteString == "https://api.test/users")
+    }
+
+    @Test func groupAddsSlashWhenBothMissing() async throws {
+        // Neither baseURL nor path has a separator — a '/' must be inserted.
+        let invoker = MockInvoker(status: 200, body: "{}")
+        let group = HTTPToolGroup(baseURL: "https://api.test", invoker: invoker)
+        let tool = group.get("items", "items", "")
+        _ = try await tool.run(.object([:]))
+        #expect(invoker.request?.url?.absoluteString == "https://api.test/items")
     }
 
     // MARK: - Host arguments


### PR DESCRIPTION
Fixes identified in the automated review of #543 (Feat/mcp api).

## Changes

**Bug 1 — HTTPToolSpec: wrong percent-encoding for URL placeholders**
- Path placeholders now use `.urlPathComponentAllowed` (encodes `/`, preventing segment injection)
- Query placeholders now use a custom charset that encodes `&`, `=`, `+`, `#` (preventing parameter injection)

**Bug 2 — AggregateToolProvider: app-only tools unreachable**
- `routing` changed to `[String:Int]?` to distinguish uninitialised from empty
- `call()` falls back to scanning providers when routing misses, so app-only tools remain callable

**Minor — HTTPToolGroup: baseURL + path double-slash**
- Added `joinURL(path:)` helper that normalises trailing/leading slashes

## Tests
Regression tests added for all three fixes.

Generated with [Claude Code](https://claude.ai/code)