### PR TITLE
fix: surface KB citations from AmazonBedrockAgent response

### DIFF
--- a/python/src/agent_squad/agents/amazon_bedrock_agent.py
+++ b/python/src/agent_squad/agents/amazon_bedrock_agent.py
@@ -137,23 +137,27 @@ class AmazonBedrockAgent(Agent):
             )
 
             completion = ""
+            citations: list = []
 
             if self.streaming:
                 async def generate_chunks():
-                    nonlocal completion
+                    nonlocal completion, citations
                     for event in response['completion']:
                         if 'chunk' in event:
                             chunk = event['chunk']
                             decoded_response = chunk['bytes'].decode('utf-8')
                             await self.callbacks.on_llm_new_token(decoded_response)
                             completion += decoded_response
+                            if 'attribution' in chunk:
+                                citations.extend(chunk['attribution'].get('citations', []))
                             yield AgentStreamResponse(text=decoded_response)
                         elif 'trace' in event and self.enableTrace:
                             Logger.info(f"Received event: {event}")
                     yield AgentStreamResponse(
                         final_message=ConversationMessage(
                             role=ParticipantRole.ASSISTANT.value,
-                            content=[{'text':completion}]))
+                            content=[{'text': completion}],
+                            citations=citations if citations else None))
                 return generate_chunks()
             else:
                 for event in response['completion']:
@@ -162,12 +166,15 @@ class AmazonBedrockAgent(Agent):
                         decoded_response = chunk['bytes'].decode('utf-8')
                         await self.callbacks.on_llm_new_token(decoded_response)
                         completion += decoded_response
+                        if 'attribution' in chunk:
+                            citations.extend(chunk['attribution'].get('citations', []))
                     elif 'trace' in event and self.enableTrace:
                         Logger.info(f"Received event: {event}")
 
                 return ConversationMessage(
                     role=ParticipantRole.ASSISTANT.value,
-                    content=[{"text": completion}]
+                    content=[{"text": completion}],
+                    citations=citations if citations else None
                 )
         except (BotoCoreError, ClientError) as error:
             # Comprehensive error logging and propagation

--- a/python/src/agent_squad/types/types.py
+++ b/python/src/agent_squad/types/types.py
@@ -44,10 +44,12 @@ class ParticipantRole(Enum):
 class ConversationMessage:
     role: ParticipantRole
     content: list[Any]
+    citations: Optional[list[Any]]
 
-    def __init__(self, role: ParticipantRole, content: Optional[list[Any]] = None):
+    def __init__(self, role: ParticipantRole, content: Optional[list[Any]] = None, citations: Optional[list[Any]] = None):
         self.role = role
         self.content = content
+        self.citations = citations
 
 class TimestampedMessage(ConversationMessage):
     def __init__(self,

--- a/python/src/tests/agents/test_amazon_bedrock_agent.py
+++ b/python/src/tests/agents/test_amazon_bedrock_agent.py
@@ -122,6 +122,59 @@ async def test_process_request_with_additional_params(bedrock_agent):
     assert result.content == [{"text": "Response with additional params"}]
 
 
+@pytest.mark.asyncio
+async def test_citations_captured_from_attribution(bedrock_agent):
+    citation = {
+        "generatedResponsePart": {"textResponsePart": {"text": "Paris", "span": {"start": 0, "end": 5}}},
+        "retrievedReferences": [{"content": {"text": "Paris info"}, "location": {"type": "S3", "s3Location": {"uri": "s3://bucket/doc.txt"}}}],
+    }
+    mock_response = {
+        'completion': [
+            {'chunk': {'bytes': b'Paris is lovely.', 'attribution': {'citations': [citation]}}},
+        ]
+    }
+    bedrock_agent.client.invoke_agent = Mock(return_value=mock_response)
+
+    result = await bedrock_agent.process_request("Tell me about Paris", "u1", "s1", [])
+
+    assert result.content == [{"text": "Paris is lovely."}]
+    assert result.citations is not None
+    assert len(result.citations) == 1
+    assert result.citations[0] == citation
+
+
+@pytest.mark.asyncio
+async def test_no_citations_when_attribution_absent(bedrock_agent):
+    mock_response = {
+        'completion': [
+            {'chunk': {'bytes': b'Hello'}},
+        ]
+    }
+    bedrock_agent.client.invoke_agent = Mock(return_value=mock_response)
+
+    result = await bedrock_agent.process_request("Hi", "u1", "s1", [])
+
+    assert result.citations is None
+
+
+@pytest.mark.asyncio
+async def test_citations_merged_across_chunks(bedrock_agent):
+    c1 = {"generatedResponsePart": {"textResponsePart": {"text": "first"}}, "retrievedReferences": []}
+    c2 = {"generatedResponsePart": {"textResponsePart": {"text": "second"}}, "retrievedReferences": []}
+    mock_response = {
+        'completion': [
+            {'chunk': {'bytes': b'first ', 'attribution': {'citations': [c1]}}},
+            {'chunk': {'bytes': b'second', 'attribution': {'citations': [c2]}}},
+        ]
+    }
+    bedrock_agent.client.invoke_agent = Mock(return_value=mock_response)
+
+    result = await bedrock_agent.process_request("Q", "u1", "s1", [])
+
+    assert result.content == [{"text": "first second"}]
+    assert result.citations == [c1, c2]
+
+
 def test_streaming(mock_boto3_client):
     options = AmazonBedrockAgentOptions(
         name="TestAgent",

--- a/typescript/src/agents/amazonBedrockAgent.ts
+++ b/typescript/src/agents/amazonBedrockAgent.ts
@@ -102,25 +102,30 @@ export class AmazonBedrockAgent extends Agent {
       if (this.streaming){
         return this.handleStreamingResponse(response);
       } else {
+        const citations: any[] = [];
         // Aggregate chunks of response data
         for await (const chunkEvent of response.completion) {
           if (chunkEvent.chunk) {
             const chunk = chunkEvent.chunk;
             const decodedResponse = new TextDecoder("utf-8").decode(chunk.bytes);
             completion += decodedResponse;
+            if (chunk.attribution?.citations) {
+              citations.push(...chunk.attribution.citations);
+            }
           } else if (chunkEvent.trace) {
             if (this.enableTrace){
               Logger.logger.info("Trace:", JSON.stringify(chunkEvent.trace));
             }
           }
         }
-      }
 
-      // Return the completed response as a Message object
-      return {
-        role: ParticipantRole.ASSISTANT,
-        content: [{ text: completion }],
-      };
+        // Return the completed response as a Message object
+        return {
+          role: ParticipantRole.ASSISTANT,
+          content: [{ text: completion }],
+          ...(citations.length > 0 && { citations }),
+        };
+      }
     } catch (err) {
       // Handle errors encountered while invoking the Amazon Bedrock agent
       Logger.logger.error(err);

--- a/typescript/src/types/index.ts
+++ b/typescript/src/types/index.ts
@@ -41,6 +41,7 @@ export enum ParticipantRole {
 export interface ConversationMessage {
   role: ParticipantRole;
   content: any[] | undefined;
+  citations?: any[];
 }
 
 /**


### PR DESCRIPTION
## Issue Link
Fixes #192

## Summary
- `AmazonBedrockAgent` was discarding `chunk.attribution.citations` from every InvokeAgent event, so Knowledge Base source citations never reached callers
- `ConversationMessage` gains an optional `citations` field (default `None` / `undefined`) — fully backward-compatible, all existing code unaffected
- Both Python and TypeScript implementations now collect citations from chunk attribution across all chunks and attach them to the returned `ConversationMessage`
- When the agent has no KB or the response carries no attribution, `citations` is `None`/absent — identical to the previous behaviour

## Changes
- `python/src/agent_squad/types/types.py` — add `citations: Optional[list[Any]] = None` to `ConversationMessage.__init__`
- `python/src/agent_squad/agents/amazon_bedrock_agent.py` — collect `chunk['attribution']['citations']` in both streaming and non-streaming paths
- `python/src/tests/agents/test_amazon_bedrock_agent.py` — three new tests: citations captured, none when absent, merge across chunks
- `typescript/src/types/index.ts` — add optional `citations?: any[]` to `ConversationMessage`
- `typescript/src/agents/amazonBedrockAgent.ts` — collect `chunk.attribution?.citations` in the non-streaming path

## User experience
Callers that previously ignored the response field continue to work unchanged. Callers that want citations can now read `response.citations` from the `ConversationMessage` returned by `route_request`.

## Checklist
- [x] Backward-compatible (new optional field, defaults to `None`/absent)
- [x] Python tests pass (215 passed)
- [x] TypeScript builds cleanly (`tsc` exits 0)
- [x] Both language implementations updated in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)