### PR TITLE
fix(swift/tooling): use a valid CharacterSet for path-component encoding

### DIFF
--- a/swift/Sources/AgentSquad/Core/Tooling/HTTPToolSpec.swift
+++ b/swift/Sources/AgentSquad/Core/Tooling/HTTPToolSpec.swift
@@ -180,7 +180,7 @@ public struct HTTPToolSpec: Sendable {
             // query-value encoding forbids '&', '=', '+', '#' (prevents parameter injection).
             let charset: CharacterSet = Self.isInQueryPart(url, key: key)
                 ? Self.urlQueryValueAllowed
-                : .urlPathComponentAllowed
+                : Self.urlPathComponentAllowed
             let encoded = raw.addingPercentEncoding(withAllowedCharacters: charset) ?? raw
             urlString = urlString.replacingOccurrences(of: "{\(key)}", with: encoded)
             args.removeValue(forKey: key)
@@ -258,6 +258,15 @@ public struct HTTPToolSpec: Sendable {
     private static let urlQueryValueAllowed: CharacterSet = {
         var allowed = CharacterSet.urlQueryAllowed
         allowed.remove(charactersIn: "&=+#")
+        return allowed
+    }()
+
+    /// Character set safe for percent-encoding a single path component. Starts from `.urlPathAllowed`
+    /// and removes '/' so a value can't inject extra path segments. (Foundation has no built-in
+    /// `urlPathComponentAllowed`.)
+    private static let urlPathComponentAllowed: CharacterSet = {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/")
         return allowed
     }()
 


### PR DESCRIPTION
`CharacterSet` has no `urlPathComponentAllowed` member, so `HTTPToolSpec` failed to compile on Apple Foundation (`Type 'CharacterSet' has no member 'urlPathComponentAllowed'`). Define it locally from `.urlPathAllowed` minus '/', mirroring the existing `urlQueryValueAllowed`, and reference it via `Self.`.

<!-- markdownlint-disable MD041 MD043 -->
## Issue Link (REQUIRED)
<!-- This PR must be linked to an issue. PRs without a linked issue will not be merged. -->
Fixes #<!-- Add issue number here (e.g., Fixes #123) -->

## Summary
### Changes
<!-- Please provide a summary of what's being changed -->

### User experience
<!-- Please share what the user experience looks like before and after this change -->

## Checklist
If your change doesn't seem to apply, please leave them unchecked.
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] I have linked this PR to an existing issue (required)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:
* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)
</details>

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.