### PR TITLE
feat(swift): enable voice processing (AEC) in MicCapture by default

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -288,6 +288,7 @@ export default defineConfig({
 										label: 'Audio',
 										items: [
 											{ label: 'Overview', slug: 'swift/audio/overview' },
+											{ label: 'VoiceProcessedAudioIO', slug: 'swift/audio/built-in/voice-processed-audio-io' },
 											{ label: 'MicCapture', slug: 'swift/audio/built-in/mic-capture' },
 											{ label: 'AudioPlayback', slug: 'swift/audio/built-in/audio-playback' },
 											{ label: 'Custom audio', slug: 'swift/audio/custom' },

--- a/docs/src/content/docs/swift/audio/built-in/audio-playback.md
+++ b/docs/src/content/docs/swift/audio/built-in/audio-playback.md
@@ -14,12 +14,18 @@ import AgentSquadAudio
 ## Init
 
 ```swift
-public init(sampleRate: Double = 24_000)
+public init(
+    sampleRate: Double = 24_000,
+    sessionPolicy: AudioSessionPolicy = .managed,
+    configureEngine: (@Sendable (AVAudioEngine) throws -> Void)? = nil
+)
 ```
 
 | Parameter | Default | Notes |
 |---|---|---|
 | `sampleRate` | `24_000` | Sample rate in Hz for the internal float32 `AVAudioFormat`. Must match the PCM16 frames the runtime will enqueue. |
+| `sessionPolicy` | `.managed` | Who configures the `AVAudioSession` — pass the **same policy** as `MicCapture`. See [AudioSessionPolicy](/agent-squad/swift/audio/built-in/mic-capture/#audiosessionpolicy-ios-only). |
+| `configureEngine` | `nil` | Escape hatch: runs with the raw `AVAudioEngine` after the player node is attached, before the engine starts. Do **not** enable voice processing here — it belongs on the capture engine (`MicCapture`), not playback. |
 
 ---
 
@@ -40,9 +46,9 @@ public func stop()                  async          // stops player and engine
 
 ---
 
-## VoiceAudioSession (iOS only)
+## Audio session (iOS only)
 
-On iOS, `start()` calls the internal `VoiceAudioSession.activate()` helper, which configures the shared `AVAudioSession`:
+On iOS, `start()` applies the `sessionPolicy` to the shared `AVAudioSession`. With the default `.managed` policy it configures:
 
 ```
 category:  .playAndRecord
@@ -50,7 +56,7 @@ mode:      .voiceChat
 options:   [.defaultToSpeaker, .allowBluetoothHFP]
 ```
 
-If `MicCapture.start()` was already called first, the session is already active and this is a no-op. On macOS the call is compiled out and the system default audio device is used.
+If `MicCapture.start()` was already called first, the session is already active and this is a no-op. With `.custom` your closure runs instead; with `.external` the session is never touched (your app must configure and activate it before `start()`). Details on [the MicCapture page](/agent-squad/swift/audio/built-in/mic-capture/#audiosessionpolicy-ios-only). On macOS the session handling is compiled out and the system default audio device is used.
 
 ---
 

--- a/docs/src/content/docs/swift/audio/built-in/audio-playback.md
+++ b/docs/src/content/docs/swift/audio/built-in/audio-playback.md
@@ -5,6 +5,10 @@ description: AVAudioEngine-backed AudioOutput that converts PCM16 frames to floa
 
 `AudioPlayback` is part of the `AgentSquadAudio` product. It accepts PCM16 @ 24 kHz frames, converts them to float32, and schedules them on an `AVAudioPlayerNode` for continuous playback. `flush()` provides an instant barge-in cut by discarding all buffered audio.
 
+:::tip
+For voice sessions, prefer [`VoiceProcessedAudioIO`](/agent-squad/swift/audio/built-in/voice-processed-audio-io/) — playback renders through the same voice-processed engine as capture, guaranteeing echo cancellation of the assistant's audio.
+:::
+
 ```swift
 import AgentSquadAudio
 ```

--- a/docs/src/content/docs/swift/audio/built-in/mic-capture.md
+++ b/docs/src/content/docs/swift/audio/built-in/mic-capture.md
@@ -5,6 +5,8 @@ description: AVAudioEngine-backed AudioInput that taps the microphone, converts 
 
 `MicCapture` is part of the `AgentSquadAudio` product. It taps `AVAudioEngine`'s input node, converts the hardware stream to **PCM16 @ 24 kHz mono**, and yields frames through a bounded `AsyncStream<Data>`.
 
+By default it captures through Apple's **Voice-Processing I/O** unit: echo cancellation that uses the speaker signal as a hardware reference to subtract the assistant's own voice from the mic, plus noise suppression and automatic gain control.
+
 ```swift
 import AgentSquadAudio
 ```
@@ -14,13 +16,50 @@ import AgentSquadAudio
 ## Init
 
 ```swift
-public init(sampleRate: Double = 24_000, maxBufferedFrames: Int = 16)
+public init(
+    sampleRate: Double = 24_000,
+    maxBufferedFrames: Int = 16,
+    voiceProcessing: VoiceProcessing? = .default,
+    sessionPolicy: AudioSessionPolicy = .managed,
+    configureEngine: (@Sendable (AVAudioEngine) throws -> Void)? = nil
+)
 ```
 
 | Parameter | Default | Notes |
 |---|---|---|
 | `sampleRate` | `24_000` | Target sample rate in Hz. Must match what the realtime runtime expects. |
 | `maxBufferedFrames` | `16` | Capacity of the internal `AsyncStream`. Under back-pressure the **oldest** frames are dropped — the tap thread never blocks. |
+| `voiceProcessing` | `.default` | Apple Voice-Processing I/O configuration (AEC + noise suppression + AGC). Pass `nil` for raw, unprocessed capture. |
+| `sessionPolicy` | `.managed` | Who configures the `AVAudioSession` — see [AudioSessionPolicy](#audiosessionpolicy-ios-only) below. |
+| `configureEngine` | `nil` | Escape hatch: runs with the raw `AVAudioEngine` after voice processing is enabled, before the tap is installed. |
+
+---
+
+## VoiceProcessing
+
+Without voice processing, whatever `AudioPlayback` sends to the speaker leaks back into the mic — with server-side VAD, the assistant hears itself and interrupts its own answers. Voice processing is therefore **on by default**:
+
+```swift
+public struct VoiceProcessing: Sendable, Equatable {
+    public var automaticGainControl: Bool          // default true
+    public var duckingLevel: DuckingLevel          // default .default; iOS 17+/macOS 14+, ignored elsewhere
+    public enum DuckingLevel { case `default`, min, mid, max }
+    public static let `default`: VoiceProcessing
+}
+```
+
+```swift
+MicCapture()                                                              // AEC on — the default
+MicCapture(voiceProcessing: .init(duckingLevel: .min))                    // AEC on, playback stays louder
+MicCapture(voiceProcessing: .init(automaticGainControl: false))           // AEC on, no gain control
+MicCapture(voiceProcessing: nil)                                          // raw capture (previous behavior)
+```
+
+Voice-processed audio sounds "call-like" and the speaker output gets quieter — `duckingLevel: .min` counters that. Enabling voice processing changes the input node's hardware format; `MicCapture` handles the ordering internally (`setVoiceProcessingEnabled` before the format read), which is why you should not enable it yourself from `configureEngine`.
+
+:::caution
+The **simulator performs no echo cancellation** — AEC must be validated on a real device. And never enable voice processing on the playback engine (`AudioPlayback`); it belongs on capture only.
+:::
 
 ---
 
@@ -41,10 +80,13 @@ public func stop()  async              // stops engine, removes tap, finishes th
 
 ```swift
 public enum MicCaptureError: Error, Equatable {
-    case permissionDenied       // user denied mic access (iOS only)
-    case converterUnavailable   // AVAudioConverter could not be initialised for the hardware format
+    case permissionDenied                     // user denied mic access (iOS only)
+    case converterUnavailable                 // AVAudioConverter could not be initialised for the hardware format
+    case voiceProcessingUnavailable(String)   // setVoiceProcessingEnabled(true) failed; payload = underlying error
 }
 ```
+
+`voiceProcessingUnavailable` is thrown rather than silently degrading to raw (echo-prone) capture. If raw capture is an acceptable fallback for your app, catch it and retry with `voiceProcessing: nil`.
 
 ---
 
@@ -63,24 +105,36 @@ Add `NSMicrophoneUsageDescription` to your `Info.plist`. Without it the system p
 
 ---
 
-## VoiceAudioSession (iOS only)
+## AudioSessionPolicy (iOS only)
 
-On iOS, `start()` calls the internal `VoiceAudioSession.activate()` helper before installing the tap. It configures the shared `AVAudioSession`:
+`sessionPolicy` decides who configures the shared `AVAudioSession` when `start()` runs. Pass the **same policy** to `MicCapture` and `AudioPlayback` so the two can't fight over the session. On macOS the session handling is compiled out and the system default audio device is used.
 
+```swift
+public enum AudioSessionPolicy: Sendable {
+    case managed                                              // AgentSquad configures it (the default)
+    case custom(@Sendable (AVAudioSession) throws -> Void)    // AgentSquad calls YOUR closure instead
+    case external                                             // AgentSquad never touches the session
+}
 ```
-category:  .playAndRecord
-mode:      .voiceChat
-options:   [.defaultToSpeaker, .allowBluetoothHFP]
-```
 
-`VoiceAudioSession` is idempotent — re-activating an already-active session is a no-op. On macOS the call is compiled out (`#if os(iOS)`) and the system default audio device is used.
+- **`.managed`** — the default; sets `category: .playAndRecord`, `mode: .voiceChat`, `options: [.defaultToSpeaker, .allowBluetoothHFP]` and activates the session. Idempotent — re-activating an already-active session is a no-op.
+- **`.custom`** — AgentSquad drives the timing (on every `start()`) but with your configuration:
+
+  ```swift
+  let policy = AudioSessionPolicy.custom { session in
+      try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetoothHFP])
+      try session.setActive(true)
+  }
+  ```
+
+- **`.external`** — for apps that already manage their `AVAudioSession` (music, video, CallKit…). AgentSquad never touches it; you must configure **and activate** the session yourself *before* calling `start()`, otherwise the input format can read back as 0 Hz and capture fails.
 
 ---
 
 ## Usage
 
 ```swift
-let mic = MicCapture()          // 24 kHz, 16-frame queue
+let mic = MicCapture()          // 24 kHz, 16-frame queue, echo-cancelled
 try await mic.start()
 
 for await frame in mic.frames {

--- a/docs/src/content/docs/swift/audio/built-in/mic-capture.md
+++ b/docs/src/content/docs/swift/audio/built-in/mic-capture.md
@@ -7,6 +7,10 @@ description: AVAudioEngine-backed AudioInput that taps the microphone, converts 
 
 By default it captures through Apple's **Voice-Processing I/O** unit: echo cancellation that uses the speaker signal as a hardware reference to subtract the assistant's own voice from the mic, plus noise suppression and automatic gain control.
 
+:::tip
+For voice sessions, prefer [`VoiceProcessedAudioIO`](/agent-squad/swift/audio/built-in/voice-processed-audio-io/) — capture and playback on **one** engine, which guarantees the assistant's audio is in the AEC reference path. With the split `MicCapture`/`AudioPlayback` pair the reference is device-level and route-dependent.
+:::
+
 ```swift
 import AgentSquadAudio
 ```

--- a/docs/src/content/docs/swift/audio/built-in/voice-processed-audio-io.md
+++ b/docs/src/content/docs/swift/audio/built-in/voice-processed-audio-io.md
@@ -1,0 +1,70 @@
+---
+title: VoiceProcessedAudioIO
+description: Capture and playback on one voice-processed AVAudioEngine — echo cancellation with the assistant's audio guaranteed in the reference path. The recommended wiring for voice sessions.
+---
+
+`VoiceProcessedAudioIO` is part of the `AgentSquadAudio` product. It runs microphone capture **and** assistant playback on a **single** `AVAudioEngine` with Apple's Voice-Processing I/O unit enabled. Because the assistant's audio renders through the same engine's voice-processed output, it is by construction in the echo canceller's reference path — the configuration the VP unit is designed around.
+
+Conforms to **both** `AudioInput` and `AudioOutput`: pass **one instance** as both `input:` and `output:`.
+
+```swift
+import AgentSquadAudio
+
+let io = VoiceProcessedAudioIO()
+let runtime = RealtimeRuntime(session: assistant, input: io, output: io)
+try await runtime.start()
+```
+
+Prefer this over the separate [`MicCapture`](/agent-squad/swift/audio/built-in/mic-capture/) + [`AudioPlayback`](/agent-squad/swift/audio/built-in/audio-playback/) pair for voice sessions — with two engines the echo reference is taken at the device level, which is route-dependent.
+
+---
+
+## Init
+
+```swift
+public init(
+    sampleRate: Double = 24_000,
+    maxBufferedFrames: Int = 16,
+    voiceProcessing: VoiceProcessing = .default,
+    sessionPolicy: AudioSessionPolicy = .managed,
+    configureEngine: (@Sendable (AVAudioEngine) throws -> Void)? = nil
+)
+```
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `sampleRate` | `24_000` | Both capture and playback rate. Must match what the realtime session expects (OpenAI Realtime: PCM is always 24 kHz). |
+| `maxBufferedFrames` | `16` | Capacity of the capture `AsyncStream`; oldest frames dropped under back-pressure. |
+| `voiceProcessing` | `.default` | AEC + noise suppression + AGC tuning. **Non-optional** — raw capture defeats this class's purpose; use `MicCapture(voiceProcessing: nil)` for that. |
+| `sessionPolicy` | `.managed` | Who configures the `AVAudioSession` — see [AudioSessionPolicy](/agent-squad/swift/audio/built-in/mic-capture/#audiosessionpolicy-ios-only). |
+| `configureEngine` | `nil` | Escape hatch: runs with the raw `AVAudioEngine` after voice processing is enabled and the player is wired, before the tap is installed. |
+
+---
+
+## Public surface
+
+```swift
+public let frames: AsyncStream<Data>    // AudioInput — captured PCM16 LE mono frames
+
+public func start() async throws        // both roles; idempotent
+public func enqueue(_ pcm16: Data) async // AudioOutput — schedule one frame
+public func flush() async                // AudioOutput — instant barge-in cut
+public func stop()  async                // both roles; idempotent
+```
+
+`start()` and `stop()` are **idempotent** — `RealtimeRuntime` calls each twice on the same instance (once through the `AudioOutput` role, once through `AudioInput`), and the second call is a no-op. `enqueue`/`flush` before `start()` or after `stop()` are safe no-ops. One instance serves **one session**: `stop()` finishes the `frames` stream for good — create a new instance to start again.
+
+Failure modes are the shared [`MicCaptureError`](/agent-squad/swift/audio/built-in/mic-capture/#miccaptureerror) cases: `permissionDenied`, `converterUnavailable`, `voiceProcessingUnavailable`.
+
+:::caution
+The **simulator performs no echo cancellation** — validate AEC on a real device. Voice-processed output sounds "call-like" and slightly quieter; counter with `duckingLevel: .min`.
+:::
+
+---
+
+## Related pages
+
+- [Audio overview](/agent-squad/swift/audio/overview/) — the `AudioInput`/`AudioOutput` protocols
+- [MicCapture](/agent-squad/swift/audio/built-in/mic-capture/) — capture-only built-in (split-pair wiring, `VoiceProcessing`, `AudioSessionPolicy` docs)
+- [AudioPlayback](/agent-squad/swift/audio/built-in/audio-playback/) — playback-only built-in
+- [Voice overview](/agent-squad/swift/voice/overview/) — the `RealtimeRuntime` that consumes this class

--- a/docs/src/content/docs/swift/audio/overview.md
+++ b/docs/src/content/docs/swift/audio/overview.md
@@ -3,11 +3,11 @@ title: Audio overview
 description: The AgentSquadAudio product and the AudioInput/AudioOutput protocols that connect microphone capture and speaker playback to the voice runtime.
 ---
 
-`AgentSquadAudio` is a separate Swift package product that ships two AVFoundation-backed implementations — `MicCapture` and `AudioPlayback` — built on top of two protocols declared in the core `AgentSquad` module.
+`AgentSquadAudio` is a separate Swift package product that ships three AVFoundation-backed implementations — `VoiceProcessedAudioIO` (the recommended one), `MicCapture`, and `AudioPlayback` — built on top of two protocols declared in the core `AgentSquad` module.
 
 ```swift
 import AgentSquad        // AudioInput, AudioOutput protocols
-import AgentSquadAudio   // MicCapture, AudioPlayback
+import AgentSquadAudio   // VoiceProcessedAudioIO, MicCapture, AudioPlayback
 ```
 
 ---
@@ -48,14 +48,17 @@ public protocol AudioOutput: Sendable {
 
 ## How they feed the voice runtime
 
-[`RealtimeRuntime`](/agent-squad/swift/voice/overview/) accepts an `AudioInput` and an `AudioOutput` at construction time:
+[`RealtimeRuntime`](/agent-squad/swift/voice/overview/) accepts an `AudioInput` and an `AudioOutput` at construction time. The recommended wiring is one `VoiceProcessedAudioIO` instance in both roles — capture and playback share a single voice-processed engine, so the assistant's audio is guaranteed to be in the echo canceller's reference path:
 
 ```swift
-let runtime = RealtimeRuntime(
-    input:  MicCapture(),
-    output: AudioPlayback(),
-    // ... other config
-)
+let io = VoiceProcessedAudioIO()
+let runtime = RealtimeRuntime(session: assistant, input: io, output: io)
+```
+
+The split pair works too (the AEC reference is then device-level, which is route-dependent):
+
+```swift
+let runtime = RealtimeRuntime(session: assistant, input: MicCapture(), output: AudioPlayback())
 ```
 
 The runtime drives `start`, `stop`, `enqueue`, and `flush` from its single event pump, so implementations are never called concurrently by the runtime itself.
@@ -70,7 +73,8 @@ The wire format for both protocols is **PCM16 little-endian mono at 24 kHz**. Th
 
 | Type | Protocol | Description |
 |---|---|---|
-| [`MicCapture`](/agent-squad/swift/audio/built-in/mic-capture/) | `AudioInput` | AVAudioEngine tap → PCM16 @ 24 kHz, with iOS permission gating |
+| [`VoiceProcessedAudioIO`](/agent-squad/swift/audio/built-in/voice-processed-audio-io/) | `AudioInput` + `AudioOutput` | Capture and playback on **one** voice-processed engine — guaranteed AEC reference path; pass one instance as both input and output |
+| [`MicCapture`](/agent-squad/swift/audio/built-in/mic-capture/) | `AudioInput` | AVAudioEngine tap → PCM16 @ 24 kHz, voice-processed by default, with iOS permission gating |
 | [`AudioPlayback`](/agent-squad/swift/audio/built-in/audio-playback/) | `AudioOutput` | AVAudioEngine + AVAudioPlayerNode, with barge-in flush |
 
 ---

--- a/swift/README.md
+++ b/swift/README.md
@@ -214,7 +214,7 @@ the integrations you need (each isolates its own dependencies):
 |---|---|---|---|
 | **`AgentSquad`** (core) | `import AgentSquad` | **nothing external** | protocols, agents, orchestrator, native tools (`ToolKit`, `Tool.local`/`.http`, `HTTPToolGroup`, `AggregateToolProvider`), `FileChatStorage`, `DeviceChatStorage` _(iOS 17+)_, `InMemoryChatStorage`, `OSLogTracer` |
 | **`AgentSquadMCP`** | `import AgentSquadMCP` | the official [MCP Swift SDK](https://github.com/modelcontextprotocol/swift-sdk) | `MCPServer` (alias of `MCPToolProvider`) — connect any MCP server with `MCPServer(url:)`, with MCP Apps UI support |
-| **`AgentSquadAudio`** | `import AgentSquadAudio` | AVFoundation (Apple platforms only) | `MicCapture` + `AudioPlayback` for the realtime voice runtime — requires `NSMicrophoneUsageDescription` in your Info.plist |
+| **`AgentSquadAudio`** | `import AgentSquadAudio` | AVFoundation (Apple platforms only) | `MicCapture` (echo-cancelled by default) + `AudioPlayback` for the realtime voice runtime — requires `NSMicrophoneUsageDescription` in your Info.plist |
 
 So an app that doesn't use MCP never downloads the MCP SDK. Future optional integrations
 (e.g. `AgentSquadLangfuse` for trace export) follow the same pattern — the core never grows a
@@ -226,6 +226,82 @@ dependency. Add a product to your target's `dependencies` to use it:
     .product(name: "AgentSquadMCP", package: "agent-squad"),   // only if you want MCP tools
 ])
 ```
+
+## Voice audio — echo cancellation and full control
+
+By default `MicCapture` captures through Apple's **Voice-Processing I/O** unit — the native
+equivalent of what ChatGPT's voice mode gets via WebRTC. The signal sent to the speaker is used
+as a hardware reference to subtract the assistant's own voice from the mic, plus noise
+suppression and automatic gain control. Without it, the assistant hears itself through the
+speaker and interrupts its own answers.
+
+The audio layer is configurable in four independent levels — each level keeps everything the
+previous levels give you:
+
+**Level 0 — defaults.** Echo-cancelled capture, nothing to configure:
+
+```swift
+import AgentSquadAudio
+
+let runtime = RealtimeRuntime(session: assistant, input: MicCapture(), output: AudioPlayback())
+try await runtime.start()
+```
+
+**Level 1 — tune voice processing** (or turn it off):
+
+```swift
+// Keep AEC but disable gain control and minimize how much the system ducks playback volume:
+let mic = MicCapture(voiceProcessing: .init(automaticGainControl: false, duckingLevel: .min))
+
+// Raw capture — no AEC at all (the previous default):
+let rawMic = MicCapture(voiceProcessing: nil)
+```
+
+If the Voice-Processing unit can't be enabled, `start()` throws
+`MicCaptureError.voiceProcessingUnavailable(_:)` rather than silently degrading — catch it and
+retry with `voiceProcessing: nil` if raw capture is an acceptable fallback for your app.
+
+**Level 2 — own the `AVAudioSession`, or reach the raw engine.** Both `MicCapture` and
+`AudioPlayback` take an `AudioSessionPolicy`; give them the same one so they can't fight:
+
+```swift
+// Your app already manages its AVAudioSession (music, video, CallKit…) — AgentSquad won't touch it.
+// You must configure AND activate the session yourself before runtime.start().
+let mic = MicCapture(sessionPolicy: .external)
+let out = AudioPlayback(sessionPolicy: .external)
+
+// Or let AgentSquad drive the timing but with YOUR configuration (iOS):
+let policy = AudioSessionPolicy.custom { session in
+    try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetoothHFP])   // no speaker override
+    try session.setActive(true)
+}
+let mic2 = MicCapture(sessionPolicy: policy)
+let out2 = AudioPlayback(sessionPolicy: policy)
+```
+
+The `configureEngine` hook hands you the underlying `AVAudioEngine` at the right lifecycle
+moment (after voice processing is enabled, before the tap is installed), so any AVFoundation
+API stays reachable without forking the class:
+
+```swift
+let mic = MicCapture(configureEngine: { engine in
+    // e.g. inspect engine.inputNode, insert effect nodes, adopt future AVFoundation APIs…
+})
+```
+
+**Level 3 — replace the audio path entirely.** `AudioInput`/`AudioOutput` are protocols and
+`RealtimeRuntime` accepts any conformer — bring WebRTC capture, CallKit audio, or a fully custom
+pipeline and keep the rest of the stack (transport, VAD, tools, tracing):
+
+```swift
+final class MyCapture: AudioInput { /* frames, start(), stop() */ }
+let runtime = RealtimeRuntime(session: assistant, input: MyCapture(), output: AudioPlayback())
+```
+
+> **Validate on a real device.** The simulator performs no echo cancellation at all, so AEC can't
+> be tested there. Expect voice-processed audio to sound "call-like" and slightly quieter — use
+> `duckingLevel: .min` to compensate. Never enable voice processing on the playback engine; it
+> belongs on capture only.
 
 ## Architecture
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -214,7 +214,7 @@ the integrations you need (each isolates its own dependencies):
 |---|---|---|---|
 | **`AgentSquad`** (core) | `import AgentSquad` | **nothing external** | protocols, agents, orchestrator, native tools (`ToolKit`, `Tool.local`/`.http`, `HTTPToolGroup`, `AggregateToolProvider`), `FileChatStorage`, `DeviceChatStorage` _(iOS 17+)_, `InMemoryChatStorage`, `OSLogTracer` |
 | **`AgentSquadMCP`** | `import AgentSquadMCP` | the official [MCP Swift SDK](https://github.com/modelcontextprotocol/swift-sdk) | `MCPServer` (alias of `MCPToolProvider`) — connect any MCP server with `MCPServer(url:)`, with MCP Apps UI support |
-| **`AgentSquadAudio`** | `import AgentSquadAudio` | AVFoundation (Apple platforms only) | `MicCapture` (echo-cancelled by default) + `AudioPlayback` for the realtime voice runtime — requires `NSMicrophoneUsageDescription` in your Info.plist |
+| **`AgentSquadAudio`** | `import AgentSquadAudio` | AVFoundation (Apple platforms only) | `VoiceProcessedAudioIO` (echo-cancelled capture + playback on one engine — the recommended wiring), `MicCapture`, `AudioPlayback` for the realtime voice runtime — requires `NSMicrophoneUsageDescription` in your Info.plist |
 
 So an app that doesn't use MCP never downloads the MCP SDK. Future optional integrations
 (e.g. `AgentSquadLangfuse` for trace export) follow the same pattern — the core never grows a
@@ -229,7 +229,7 @@ dependency. Add a product to your target's `dependencies` to use it:
 
 ## Voice audio — echo cancellation and full control
 
-By default `MicCapture` captures through Apple's **Voice-Processing I/O** unit — the native
+The audio layer captures through Apple's **Voice-Processing I/O** unit by default — the native
 equivalent of what ChatGPT's voice mode gets via WebRTC. The signal sent to the speaker is used
 as a hardware reference to subtract the assistant's own voice from the mic, plus noise
 suppression and automatic gain control. Without it, the assistant hears itself through the
@@ -238,22 +238,30 @@ speaker and interrupts its own answers.
 The audio layer is configurable in four independent levels — each level keeps everything the
 previous levels give you:
 
-**Level 0 — defaults.** Echo-cancelled capture, nothing to configure:
+**Level 0 — defaults.** `VoiceProcessedAudioIO` runs capture **and** playback on one
+`AVAudioEngine`, so the assistant's audio renders through the voice-processed output and is by
+construction in the echo canceller's reference path. Pass one instance as both `input:` and
+`output:`:
 
 ```swift
 import AgentSquadAudio
 
-let runtime = RealtimeRuntime(session: assistant, input: MicCapture(), output: AudioPlayback())
+let io = VoiceProcessedAudioIO()
+let runtime = RealtimeRuntime(session: assistant, input: io, output: io)
 try await runtime.start()
 ```
+
+The separate `MicCapture` + `AudioPlayback` pair still works (both echo-cancelled on the capture
+side by default) — but with two engines the echo reference is taken at the device level, which is
+route-dependent. Prefer `VoiceProcessedAudioIO` for voice sessions.
 
 **Level 1 — tune voice processing** (or turn it off):
 
 ```swift
 // Keep AEC but disable gain control and minimize how much the system ducks playback volume:
-let mic = MicCapture(voiceProcessing: .init(automaticGainControl: false, duckingLevel: .min))
+let io = VoiceProcessedAudioIO(voiceProcessing: .init(automaticGainControl: false, duckingLevel: .min))
 
-// Raw capture — no AEC at all (the previous default):
+// Raw capture — no AEC at all (the previous default; split pair only):
 let rawMic = MicCapture(voiceProcessing: nil)
 ```
 
@@ -261,22 +269,19 @@ If the Voice-Processing unit can't be enabled, `start()` throws
 `MicCaptureError.voiceProcessingUnavailable(_:)` rather than silently degrading — catch it and
 retry with `voiceProcessing: nil` if raw capture is an acceptable fallback for your app.
 
-**Level 2 — own the `AVAudioSession`, or reach the raw engine.** Both `MicCapture` and
-`AudioPlayback` take an `AudioSessionPolicy`; give them the same one so they can't fight:
+**Level 2 — own the `AVAudioSession`, or reach the raw engine.** All three audio classes take
+an `AudioSessionPolicy` (if you use the split pair, give both the same one so they can't fight):
 
 ```swift
 // Your app already manages its AVAudioSession (music, video, CallKit…) — AgentSquad won't touch it.
 // You must configure AND activate the session yourself before runtime.start().
-let mic = MicCapture(sessionPolicy: .external)
-let out = AudioPlayback(sessionPolicy: .external)
+let io = VoiceProcessedAudioIO(sessionPolicy: .external)
 
 // Or let AgentSquad drive the timing but with YOUR configuration (iOS):
-let policy = AudioSessionPolicy.custom { session in
+let io2 = VoiceProcessedAudioIO(sessionPolicy: .custom { session in
     try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetoothHFP])   // no speaker override
     try session.setActive(true)
-}
-let mic2 = MicCapture(sessionPolicy: policy)
-let out2 = AudioPlayback(sessionPolicy: policy)
+})
 ```
 
 The `configureEngine` hook hands you the underlying `AVAudioEngine` at the right lifecycle
@@ -284,7 +289,7 @@ moment (after voice processing is enabled, before the tap is installed), so any 
 API stays reachable without forking the class:
 
 ```swift
-let mic = MicCapture(configureEngine: { engine in
+let io = VoiceProcessedAudioIO(configureEngine: { engine in
     // e.g. inspect engine.inputNode, insert effect nodes, adopt future AVFoundation APIs…
 })
 ```

--- a/swift/SKILL.md
+++ b/swift/SKILL.md
@@ -33,7 +33,7 @@ Every component is a `Sendable` protocol with one built-in implementation — sw
 |---|---|---|
 | `AgentSquad` | nothing external | protocols, `Agent`, `GroundedAgent`, `Orchestrator`, `LLMClassifier`, `ChatCompletionsClient`, `FileChatStorage`, `DeviceChatStorage`, `InMemoryChatStorage`, `OSLogTracer`, OTLP export |
 | `AgentSquadMCP` | MCP Swift SDK | `MCPServer` (= `MCPToolProvider`), `SDKMCPClient` |
-| `AgentSquadAudio` | AVFoundation | `MicCapture` (voice-processed/AEC by default), `AudioPlayback`, `VoiceProcessing`, `AudioSessionPolicy` (needs `NSMicrophoneUsageDescription`) |
+| `AgentSquadAudio` | AVFoundation | `VoiceProcessedAudioIO` (capture+playback, one engine, AEC — the recommended wiring), `MicCapture` (voice-processed/AEC by default), `AudioPlayback`, `VoiceProcessing`, `AudioSessionPolicy` (needs `NSMicrophoneUsageDescription`) |
 
 SwiftPM: `.package(url: "https://github.com/2FastLabs/agent-squad", branch: "main")`.
 
@@ -76,10 +76,13 @@ stream. `.final` is what the orchestrator persists. Inputs/messages are value ty
 - **Voice**: two `VoiceAssistant`s over a WebSocket — `OpenAIVoiceAssistant` (single LLM, speaks
   directly) and `OpenAIGroundedVoiceAssistant` (grounded Brain → Presenter). Both are self-sufficient
   (own `tracer`/`store`/`userId`/`sessionId`; with a `store`, completed turns persist and prior
-  history seeds on `start()`), wired to the mic/speaker by `RealtimeRuntime` with `MicCapture`/`AudioPlayback`.
-  `MicCapture` captures through Apple's Voice-Processing I/O unit by default (echo cancellation,
-  noise suppression, AGC — tune via `voiceProcessing:`, or pass `nil` for raw capture); both audio
-  classes take an `AudioSessionPolicy` (`.managed` / `.custom` / `.external` for apps that own the
+  history seeds on `start()`), wired to the mic/speaker by `RealtimeRuntime`. Preferred audio
+  wiring: ONE `VoiceProcessedAudioIO` instance passed as both `input:` and `output:` — capture and
+  playback share one voice-processed `AVAudioEngine`, so the assistant's audio is guaranteed to be
+  in the echo canceller's reference path. The split `MicCapture`/`AudioPlayback` pair also works
+  (capture is voice-processed by default; the AEC reference is then device-level/route-dependent;
+  `MicCapture(voiceProcessing: nil)` = raw capture). All three audio classes take an
+  `AudioSessionPolicy` (`.managed` / `.custom` / `.external` for apps that own the
   `AVAudioSession`) and a `configureEngine` hook exposing the raw `AVAudioEngine`.
   Session tuning on both: `transcriptionModel` (the user's STT only), `turnDetection`
   (`.semanticVAD(eagerness:)` / `.serverVAD(threshold:…)` / `.disabled`), and `sessionOverrides`
@@ -121,12 +124,14 @@ signatures live in `Sources/AgentSquad/`.
   pattern-scrub PII — supply a custom `Redactor` for that.
 - **Realtime** is a peer runtime, not an agent; its `events` stream is non-throwing; needs
   `NSMicrophoneUsageDescription`; always `stop()`.
-- **Voice processing (AEC)**: on by default in `MicCapture`; if it can't be enabled `start()`
-  throws `.voiceProcessingUnavailable` (degrade deliberately with `voiceProcessing: nil`). The
+- **Voice processing (AEC)**: on by default; if it can't be enabled `start()` throws
+  `.voiceProcessingUnavailable` (degrade deliberately with `MicCapture(voiceProcessing: nil)`).
+  For guaranteed echo cancellation use `VoiceProcessedAudioIO` and pass the **same instance** as
+  input and output (its `start()`/`stop()` are idempotent — the runtime calls each twice). The
   simulator does **no** AEC — validate on a device. VP quiets the speaker (counter with
-  `duckingLevel: .min`); never enable VP on the playback engine. With `sessionPolicy: .external`
-  the app must configure **and activate** its `AVAudioSession` before `start()`, and should pass
-  the same policy to both `MicCapture` and `AudioPlayback`.
+  `duckingLevel: .min`); never enable VP on a playback-only engine. With
+  `sessionPolicy: .external` the app must configure **and activate** its `AVAudioSession` before
+  `start()`, and should use the same policy everywhere.
 - **`ContentPart` Codable** keys off case + label names — renaming breaks stored history.
 
 ## Go deeper

--- a/swift/SKILL.md
+++ b/swift/SKILL.md
@@ -33,7 +33,7 @@ Every component is a `Sendable` protocol with one built-in implementation — sw
 |---|---|---|
 | `AgentSquad` | nothing external | protocols, `Agent`, `GroundedAgent`, `Orchestrator`, `LLMClassifier`, `ChatCompletionsClient`, `FileChatStorage`, `DeviceChatStorage`, `InMemoryChatStorage`, `OSLogTracer`, OTLP export |
 | `AgentSquadMCP` | MCP Swift SDK | `MCPServer` (= `MCPToolProvider`), `SDKMCPClient` |
-| `AgentSquadAudio` | AVFoundation | `MicCapture`, `AudioPlayback` (needs `NSMicrophoneUsageDescription`) |
+| `AgentSquadAudio` | AVFoundation | `MicCapture` (voice-processed/AEC by default), `AudioPlayback`, `VoiceProcessing`, `AudioSessionPolicy` (needs `NSMicrophoneUsageDescription`) |
 
 SwiftPM: `.package(url: "https://github.com/2FastLabs/agent-squad", branch: "main")`.
 
@@ -77,6 +77,10 @@ stream. `.final` is what the orchestrator persists. Inputs/messages are value ty
   directly) and `OpenAIGroundedVoiceAssistant` (grounded Brain → Presenter). Both are self-sufficient
   (own `tracer`/`store`/`userId`/`sessionId`; with a `store`, completed turns persist and prior
   history seeds on `start()`), wired to the mic/speaker by `RealtimeRuntime` with `MicCapture`/`AudioPlayback`.
+  `MicCapture` captures through Apple's Voice-Processing I/O unit by default (echo cancellation,
+  noise suppression, AGC — tune via `voiceProcessing:`, or pass `nil` for raw capture); both audio
+  classes take an `AudioSessionPolicy` (`.managed` / `.custom` / `.external` for apps that own the
+  `AVAudioSession`) and a `configureEngine` hook exposing the raw `AVAudioEngine`.
   Session tuning on both: `transcriptionModel` (the user's STT only), `turnDetection`
   (`.semanticVAD(eagerness:)` / `.serverVAD(threshold:…)` / `.disabled`), and `sessionOverrides`
   (deep-merged into the generated `session.update` last — the escape hatch for unmodeled keys like
@@ -99,6 +103,7 @@ signatures live in `Sources/AgentSquad/`.
 | Storage | `ChatStorage` | `Core/Storage/` · `storage/custom` |
 | Tracing | `TraceExporter` (easiest) / `SpanProcessor` / `Tracer` / `Redactor` | `Core/Tracing/` · `tracing/custom` |
 | Realtime transport | `RealtimeTransport` | `Runtimes/Realtime/` · `voice/custom` |
+| Audio I/O | `AudioInput` / `AudioOutput` | `Runtimes/Realtime/AudioIO.swift` · `audio/custom` |
 
 ## Gotchas
 
@@ -116,6 +121,12 @@ signatures live in `Sources/AgentSquad/`.
   pattern-scrub PII — supply a custom `Redactor` for that.
 - **Realtime** is a peer runtime, not an agent; its `events` stream is non-throwing; needs
   `NSMicrophoneUsageDescription`; always `stop()`.
+- **Voice processing (AEC)**: on by default in `MicCapture`; if it can't be enabled `start()`
+  throws `.voiceProcessingUnavailable` (degrade deliberately with `voiceProcessing: nil`). The
+  simulator does **no** AEC — validate on a device. VP quiets the speaker (counter with
+  `duckingLevel: .min`); never enable VP on the playback engine. With `sessionPolicy: .external`
+  the app must configure **and activate** its `AVAudioSession` before `start()`, and should pass
+  the same policy to both `MicCapture` and `AudioPlayback`.
 - **`ContentPart` Codable** keys off case + label names — renaming breaks stored history.
 
 ## Go deeper

--- a/swift/Sources/AgentSquadAudio/AudioConfiguration.swift
+++ b/swift/Sources/AgentSquadAudio/AudioConfiguration.swift
@@ -23,8 +23,21 @@ public struct VoiceProcessing: Sendable, Equatable {
     public static let `default` = VoiceProcessing()
 }
 
-/// Who configures the `AVAudioSession`. `MicCapture` and `AudioPlayback` take the same policy so
-/// the two can't fight over the session. No effect on macOS (no `AVAudioSession` there).
+extension VoiceProcessing.DuckingLevel {
+    @available(iOS 17.0, macOS 14.0, *)
+    var avLevel: AVAudioVoiceProcessingOtherAudioDuckingConfiguration.Level {
+        switch self {
+        case .default: .default
+        case .min: .min
+        case .mid: .mid
+        case .max: .max
+        }
+    }
+}
+
+/// Who configures the `AVAudioSession`. All audio classes take a policy; if you use the split
+/// `MicCapture`/`AudioPlayback` pair, give both the same one so they can't fight over the
+/// session. No effect on macOS (no `AVAudioSession` there).
 public enum AudioSessionPolicy: Sendable {
     /// AgentSquad configures it: `.playAndRecord`, `.voiceChat`, speaker output, Bluetooth HFP.
     case managed

--- a/swift/Sources/AgentSquadAudio/AudioConfiguration.swift
+++ b/swift/Sources/AgentSquadAudio/AudioConfiguration.swift
@@ -1,0 +1,38 @@
+import AVFoundation
+
+/// Apple Voice-Processing I/O configuration for `MicCapture`: hardware echo cancellation (the
+/// speaker signal is the subtraction reference), noise suppression, and gain control. `nil` on
+/// `MicCapture.init` = raw capture.
+public struct VoiceProcessing: Sendable, Equatable {
+    /// Automatic gain control on the captured speech.
+    public var automaticGainControl: Bool
+
+    /// How hard the system ducks other audio while capture runs (iOS 17+/macOS 14+, ignored
+    /// elsewhere). `.min` counters the "speaker got quieter" side effect of voice processing.
+    public var duckingLevel: DuckingLevel
+
+    public enum DuckingLevel: Sendable, Equatable {
+        case `default`, min, mid, max
+    }
+
+    public init(automaticGainControl: Bool = true, duckingLevel: DuckingLevel = .default) {
+        self.automaticGainControl = automaticGainControl
+        self.duckingLevel = duckingLevel
+    }
+
+    public static let `default` = VoiceProcessing()
+}
+
+/// Who configures the `AVAudioSession`. `MicCapture` and `AudioPlayback` take the same policy so
+/// the two can't fight over the session. No effect on macOS (no `AVAudioSession` there).
+public enum AudioSessionPolicy: Sendable {
+    /// AgentSquad configures it: `.playAndRecord`, `.voiceChat`, speaker output, Bluetooth HFP.
+    case managed
+    #if os(iOS)
+    /// AgentSquad calls your closure (on every `start()`) instead of its own setup.
+    case custom(@Sendable (AVAudioSession) throws -> Void)
+    #endif
+    /// AgentSquad never touches the session — the app owns category, mode, and activation, and
+    /// must activate it before `start()`.
+    case external
+}

--- a/swift/Sources/AgentSquadAudio/AudioPlayback.swift
+++ b/swift/Sources/AgentSquadAudio/AudioPlayback.swift
@@ -71,12 +71,7 @@ public final class AudioPlayback: AudioOutput, @unchecked Sendable {
     }
 
     private func makeBuffer(_ data: Data) -> AVAudioPCMBuffer? {
-        let samples = Self.floatSamples(fromPCM16: data)
-        guard !samples.isEmpty, let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count)) else { return nil }
-        buffer.frameLength = AVAudioFrameCount(samples.count)
-        let channel = buffer.floatChannelData![0]
-        for i in samples.indices { channel[i] = samples[i] }
-        return buffer
+        PCM16.floatBuffer(fromPCM16: data, format: format)
     }
 
     /// PCM16 little-endian mono bytes → float32 samples in `[-1, 1]`. Pure (no engine) so the

--- a/swift/Sources/AgentSquadAudio/AudioPlayback.swift
+++ b/swift/Sources/AgentSquadAudio/AudioPlayback.swift
@@ -11,21 +11,33 @@ public final class AudioPlayback: AudioOutput, @unchecked Sendable {
     private let engine = AVAudioEngine()
     private let player = AVAudioPlayerNode()
     private let format: AVAudioFormat
+    private let sessionPolicy: AudioSessionPolicy
+    private let configureEngine: (@Sendable (AVAudioEngine) throws -> Void)?
     private var isStarted = false
 
-    public init(sampleRate: Double = 24_000) {
+    /// `configureEngine` runs after the player is attached/connected, before the engine starts —
+    /// the escape hatch to any `AVAudioEngine` API AgentSquad doesn't wrap. Do NOT enable voice
+    /// processing here: it belongs on the capture engine (`MicCapture`), not playback.
+    public init(
+        sampleRate: Double = 24_000,
+        sessionPolicy: AudioSessionPolicy = .managed,
+        configureEngine: (@Sendable (AVAudioEngine) throws -> Void)? = nil
+    ) {
         self.format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!   // float32, non-interleaved
+        self.sessionPolicy = sessionPolicy
+        self.configureEngine = configureEngine
     }
 
     public func start() async throws {
         guard !isStarted else { return }   // start-once: a second engine.attach(player) would crash
         #if os(iOS)
-        try VoiceAudioSession.activate()
+        try VoiceAudioSession.activate(policy: sessionPolicy)
         #endif
         engine.attach(player)
         engine.connect(player, to: engine.mainMixerNode, format: format)
-        engine.prepare()
         do {
+            try configureEngine?(engine)
+            engine.prepare()
             try engine.start()
         } catch {
             engine.detach(player)   // roll back so a retry's attach(player) doesn't crash

--- a/swift/Sources/AgentSquadAudio/MicCapture.swift
+++ b/swift/Sources/AgentSquadAudio/MicCapture.swift
@@ -4,6 +4,10 @@ import AgentSquad
 /// `AudioInput` over `AVAudioEngine`: taps the mic, converts to PCM16 @ 24 kHz mono, and yields
 /// frames into a **bounded, drop-oldest** `AsyncStream` (the real-time tap thread must never block).
 ///
+/// By default the capture runs through Apple's **Voice-Processing I/O** unit — echo cancellation
+/// using the speaker signal as hardware reference, noise suppression, AGC. Pass
+/// `voiceProcessing: nil` for raw capture. AEC is inert in the simulator; validate on a device.
+///
 /// `@unchecked Sendable`: `start`/`stop` are not safe to call concurrently (callers must serialize;
 /// `RealtimeRuntime` does). The converter lives in the tap closure and is touched only on the audio
 /// thread; the stream `continuation` is itself Sendable.
@@ -12,18 +16,32 @@ public final class MicCapture: AudioInput, @unchecked Sendable {
     private let continuation: AsyncStream<Data>.Continuation
     private let engine = AVAudioEngine()
     private let targetFormat: AVAudioFormat
+    private let voiceProcessing: VoiceProcessing?
+    private let sessionPolicy: AudioSessionPolicy
+    private let configureEngine: (@Sendable (AVAudioEngine) throws -> Void)?
     private var isStarted = false
 
     /// `maxBufferedFrames` bounds the queue — under back-pressure the oldest frames are dropped.
-    public init(sampleRate: Double = 24_000, maxBufferedFrames: Int = 16) {
+    /// `configureEngine` runs after voice processing is enabled but before the tap is installed —
+    /// the escape hatch to any `AVAudioEngine` API AgentSquad doesn't wrap.
+    public init(
+        sampleRate: Double = 24_000,
+        maxBufferedFrames: Int = 16,
+        voiceProcessing: VoiceProcessing? = .default,
+        sessionPolicy: AudioSessionPolicy = .managed,
+        configureEngine: (@Sendable (AVAudioEngine) throws -> Void)? = nil
+    ) {
         self.targetFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: sampleRate, channels: 1, interleaved: true)!
+        self.voiceProcessing = voiceProcessing
+        self.sessionPolicy = sessionPolicy
+        self.configureEngine = configureEngine
         (self.frames, self.continuation) = AsyncStream.makeStream(of: Data.self, bufferingPolicy: .bufferingNewest(maxBufferedFrames))
     }
 
     public func start() async throws {
         guard !isStarted else { return }   // start-once: a second installTap/engine.start would crash
         #if os(iOS)
-        try VoiceAudioSession.activate()
+        try VoiceAudioSession.activate(policy: sessionPolicy)
         let granted = await withCheckedContinuation { (c: CheckedContinuation<Bool, Never>) in
             // `AVAudioApplication.requestRecordPermission` is iOS 17+; fall back to the (now-deprecated)
             // `AVAudioSession` call on iOS 16. No deprecation warning fires at the iOS-16 floor.
@@ -37,8 +55,34 @@ public final class MicCapture: AudioInput, @unchecked Sendable {
         #endif
 
         let input = engine.inputNode
+        if let vp = voiceProcessing {
+            do {
+                // MUST precede the inputFormat read below — enabling VP changes the node's format.
+                try input.setVoiceProcessingEnabled(true)
+            } catch {
+                throw MicCaptureError.voiceProcessingUnavailable(String(describing: error))
+            }
+            input.isVoiceProcessingAGCEnabled = vp.automaticGainControl
+            if #available(iOS 17.0, *) {
+                input.voiceProcessingOtherAudioDuckingConfiguration = .init(
+                    enableAdvancedDucking: false, duckingLevel: vp.duckingLevel.avLevel)
+            }
+        }
+        // Roll back so a failed start leaves the node raw and a retry starts clean.
+        func rollBackVoiceProcessing() {
+            if voiceProcessing != nil { try? input.setVoiceProcessingEnabled(false) }
+        }
+
+        do {
+            try configureEngine?(engine)
+        } catch {
+            rollBackVoiceProcessing()
+            throw error
+        }
+
         let inputFormat = input.inputFormat(forBus: 0)
         guard let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+            rollBackVoiceProcessing()
             throw MicCaptureError.converterUnavailable
         }
         // Capture the converter into the tap closure, not a shared field: the tap runs on the
@@ -52,6 +96,7 @@ public final class MicCapture: AudioInput, @unchecked Sendable {
             try engine.start()
         } catch {
             input.removeTap(onBus: 0)   // roll back so a retry's installTap doesn't hit a live tap
+            rollBackVoiceProcessing()
             throw error
         }
         isStarted = true
@@ -92,7 +137,22 @@ public final class MicCapture: AudioInput, @unchecked Sendable {
     }
 }
 
+private extension VoiceProcessing.DuckingLevel {
+    @available(iOS 17.0, macOS 14.0, *)
+    var avLevel: AVAudioVoiceProcessingOtherAudioDuckingConfiguration.Level {
+        switch self {
+        case .default: .default
+        case .min: .min
+        case .mid: .mid
+        case .max: .max
+        }
+    }
+}
+
 public enum MicCaptureError: Error, Equatable {
     case permissionDenied
     case converterUnavailable
+    /// `setVoiceProcessingEnabled(true)` failed; payload is the underlying error's description.
+    /// Catch it and retry with `voiceProcessing: nil` to degrade to raw capture deliberately.
+    case voiceProcessingUnavailable(String)
 }

--- a/swift/Sources/AgentSquadAudio/MicCapture.swift
+++ b/swift/Sources/AgentSquadAudio/MicCapture.swift
@@ -114,38 +114,7 @@ public final class MicCapture: AudioInput, @unchecked Sendable {
 
     /// Runs on the real-time audio thread: convert one captured buffer to PCM16/24k and yield it.
     private func process(_ buffer: AVAudioPCMBuffer, with converter: AVAudioConverter) {
-        let ratio = targetFormat.sampleRate / buffer.format.sampleRate
-        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1_024
-        guard let output = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else { return }
-
-        // The block form is REQUIRED for sample-rate conversion (48k→24k) — `convert(to:from:)`
-        // throws on differing sample rates. Feeding one input buffer per call with the converter
-        // reused across taps is the correct *streaming* idiom: it carries resampler filter state
-        // between calls for continuity. The input block is `@Sendable` but called synchronously on
-        // this thread, so single-threaded access to these captures is safe.
-        nonisolated(unsafe) let source = buffer
-        nonisolated(unsafe) var provided = false
-        var conversionError: NSError?
-        converter.convert(to: output, error: &conversionError) { _, status in
-            if provided { status.pointee = .noDataNow; return nil }
-            provided = true
-            status.pointee = .haveData
-            return source
-        }
-        guard conversionError == nil, output.frameLength > 0, let samples = output.int16ChannelData else { return }
-        continuation.yield(Data(bytes: samples[0], count: Int(output.frameLength) * MemoryLayout<Int16>.size))
-    }
-}
-
-private extension VoiceProcessing.DuckingLevel {
-    @available(iOS 17.0, macOS 14.0, *)
-    var avLevel: AVAudioVoiceProcessingOtherAudioDuckingConfiguration.Level {
-        switch self {
-        case .default: .default
-        case .min: .min
-        case .mid: .mid
-        case .max: .max
-        }
+        PCM16.convertAndYield(buffer, converter: converter, targetFormat: targetFormat, continuation: continuation)
     }
 }
 

--- a/swift/Sources/AgentSquadAudio/PCM16.swift
+++ b/swift/Sources/AgentSquadAudio/PCM16.swift
@@ -1,0 +1,45 @@
+import AVFoundation
+
+/// Shared PCM16 ↔ engine-format conversion used by `MicCapture`, `AudioPlayback`, and
+/// `VoiceProcessedAudioIO` — one copy of the subtle real-time code.
+enum PCM16 {
+    /// Runs on the real-time audio thread: convert one captured buffer to PCM16 at
+    /// `targetFormat`'s rate and yield it into the stream.
+    static func convertAndYield(
+        _ buffer: AVAudioPCMBuffer,
+        converter: AVAudioConverter,
+        targetFormat: AVAudioFormat,
+        continuation: AsyncStream<Data>.Continuation
+    ) {
+        let ratio = targetFormat.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1_024
+        guard let output = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else { return }
+
+        // The block form is REQUIRED for sample-rate conversion (48k→24k) — `convert(to:from:)`
+        // throws on differing sample rates. Feeding one input buffer per call with the converter
+        // reused across taps is the correct *streaming* idiom: it carries resampler filter state
+        // between calls for continuity. The input block is `@Sendable` but called synchronously on
+        // this thread, so single-threaded access to these captures is safe.
+        nonisolated(unsafe) let source = buffer
+        nonisolated(unsafe) var provided = false
+        var conversionError: NSError?
+        converter.convert(to: output, error: &conversionError) { _, status in
+            if provided { status.pointee = .noDataNow; return nil }
+            provided = true
+            status.pointee = .haveData
+            return source
+        }
+        guard conversionError == nil, output.frameLength > 0, let samples = output.int16ChannelData else { return }
+        continuation.yield(Data(bytes: samples[0], count: Int(output.frameLength) * MemoryLayout<Int16>.size))
+    }
+
+    /// PCM16 LE mono bytes → float32 buffer ready to schedule on a player node.
+    static func floatBuffer(fromPCM16 data: Data, format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let samples = AudioPlayback.floatSamples(fromPCM16: data)
+        guard !samples.isEmpty, let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count)) else { return nil }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        let channel = buffer.floatChannelData![0]
+        for i in samples.indices { channel[i] = samples[i] }
+        return buffer
+    }
+}

--- a/swift/Sources/AgentSquadAudio/VoiceAudioSession.swift
+++ b/swift/Sources/AgentSquadAudio/VoiceAudioSession.swift
@@ -1,14 +1,21 @@
 #if os(iOS)
 import AVFoundation
 
-/// Shared `AVAudioSession` setup for the voice profile — one place so `MicCapture` and
-/// `AudioPlayback` can't drift to conflicting categories. Idempotent (re-activating an
-/// already-active session is a no-op).
+/// Shared `AVAudioSession` setup — one entry point so `MicCapture` and `AudioPlayback` can't
+/// drift to conflicting categories. `.managed` is idempotent (re-activating an already-active
+/// session is a no-op); a `.custom` closure runs on every `start()` and owns its own idempotency.
 enum VoiceAudioSession {
-    static func activate() throws {
-        let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .allowBluetoothHFP])
-        try session.setActive(true)
+    static func activate(policy: AudioSessionPolicy) throws {
+        switch policy {
+        case .managed:
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .allowBluetoothHFP])
+            try session.setActive(true)
+        case .custom(let configure):
+            try configure(AVAudioSession.sharedInstance())
+        case .external:
+            break
+        }
     }
 }
 #endif

--- a/swift/Sources/AgentSquadAudio/VoiceProcessedAudioIO.swift
+++ b/swift/Sources/AgentSquadAudio/VoiceProcessedAudioIO.swift
@@ -1,0 +1,151 @@
+import AVFoundation
+import AgentSquad
+import os
+
+/// Capture AND playback on **one** `AVAudioEngine` with the Voice-Processing I/O unit enabled:
+/// the assistant's audio renders through the same engine's voice-processed output, so it is by
+/// construction in the echo canceller's reference path — the configuration Apple's VP unit is
+/// designed around. Pass ONE instance as both `input:` and `output:` to `RealtimeRuntime`.
+///
+/// Prefer this over the separate `MicCapture` + `AudioPlayback` pair for voice sessions; the
+/// split pair relies on the device-level echo reference, which is route-dependent.
+///
+/// `start()`/`stop()` are idempotent — the runtime calls each twice (once per protocol role).
+/// One instance serves one session: after `stop()` the frames stream is finished for good;
+/// create a new instance to start again.
+///
+/// `@unchecked Sendable`: `isStarted` and the player/engine calls in `enqueue`/`flush`/`stop` are
+/// serialized by an internal unfair lock — actor reentrancy in `RealtimeRuntime` lets an in-flight
+/// `enqueue` overlap `stop()` (both roles hit this one object). `start()` itself must not be
+/// called concurrently with itself (the runtime awaits it sequentially, before any pump runs).
+/// The tap thread never takes the lock: it touches only the closure-owned converter and the
+/// Sendable continuation.
+public final class VoiceProcessedAudioIO: AudioInput, AudioOutput, @unchecked Sendable {
+    public let frames: AsyncStream<Data>
+    private let continuation: AsyncStream<Data>.Continuation
+    private let engine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private let captureFormat: AVAudioFormat    // PCM16 interleaved mono
+    private let playbackFormat: AVAudioFormat   // float32 non-interleaved mono
+    private let voiceProcessing: VoiceProcessing
+    private let sessionPolicy: AudioSessionPolicy
+    private let configureEngine: (@Sendable (AVAudioEngine) throws -> Void)?
+    private let lock = OSAllocatedUnfairLock()
+    private var isStarted = false   // guarded by `lock`
+
+    /// `voiceProcessing` is non-optional here — raw capture defeats this class's purpose; use
+    /// `MicCapture(voiceProcessing: nil)` for that. `configureEngine` runs after voice processing
+    /// is enabled and the player is wired, before the tap is installed.
+    public init(
+        sampleRate: Double = 24_000,
+        maxBufferedFrames: Int = 16,
+        voiceProcessing: VoiceProcessing = .default,
+        sessionPolicy: AudioSessionPolicy = .managed,
+        configureEngine: (@Sendable (AVAudioEngine) throws -> Void)? = nil
+    ) {
+        self.captureFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: sampleRate, channels: 1, interleaved: true)!
+        self.playbackFormat = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
+        self.voiceProcessing = voiceProcessing
+        self.sessionPolicy = sessionPolicy
+        self.configureEngine = configureEngine
+        (self.frames, self.continuation) = AsyncStream.makeStream(of: Data.self, bufferingPolicy: .bufferingNewest(maxBufferedFrames))
+    }
+
+    public func start() async throws {
+        guard lock.withLockUnchecked({ !isStarted }) else { return }   // idempotent: the runtime starts this as output, then as input
+        #if os(iOS)
+        try VoiceAudioSession.activate(policy: sessionPolicy)
+        let granted = await withCheckedContinuation { (c: CheckedContinuation<Bool, Never>) in
+            // `AVAudioApplication.requestRecordPermission` is iOS 17+; fall back to the (now-deprecated)
+            // `AVAudioSession` call on iOS 16. No deprecation warning fires at the iOS-16 floor.
+            if #available(iOS 17, *) {
+                AVAudioApplication.requestRecordPermission { c.resume(returning: $0) }
+            } else {
+                AVAudioSession.sharedInstance().requestRecordPermission { c.resume(returning: $0) }
+            }
+        }
+        guard granted else { throw MicCaptureError.permissionDenied }
+        #endif
+
+        let input = engine.inputNode
+        do {
+            // MUST precede the inputFormat read below — enabling VP changes the node's format.
+            try input.setVoiceProcessingEnabled(true)
+        } catch {
+            throw MicCaptureError.voiceProcessingUnavailable(String(describing: error))
+        }
+        input.isVoiceProcessingAGCEnabled = voiceProcessing.automaticGainControl
+        if #available(iOS 17.0, *) {
+            input.voiceProcessingOtherAudioDuckingConfiguration = .init(
+                enableAdvancedDucking: false, duckingLevel: voiceProcessing.duckingLevel.avLevel)
+        }
+
+        // Playback wired into the SAME engine — this is the whole point: the player's audio goes
+        // out through the voice-processed output and lands in the AEC reference.
+        engine.attach(player)
+        engine.connect(player, to: engine.mainMixerNode, format: playbackFormat)
+
+        // Roll back so a failed start leaves the engine raw/detached and a retry starts clean.
+        func rollBack(tapInstalled: Bool) {
+            if tapInstalled { input.removeTap(onBus: 0) }
+            engine.detach(player)
+            try? input.setVoiceProcessingEnabled(false)
+        }
+
+        do {
+            try configureEngine?(engine)
+        } catch {
+            rollBack(tapInstalled: false)
+            throw error
+        }
+
+        let inputFormat = input.inputFormat(forBus: 0)
+        guard let converter = AVAudioConverter(from: inputFormat, to: captureFormat) else {
+            rollBack(tapInstalled: false)
+            throw MicCaptureError.converterUnavailable
+        }
+        // Converter owned by the tap closure, not a shared field — see MicCapture for the rationale.
+        input.installTap(onBus: 0, bufferSize: 2_048, format: inputFormat) { [weak self] buffer, _ in
+            guard let self else { return }
+            PCM16.convertAndYield(buffer, converter: converter, targetFormat: self.captureFormat, continuation: self.continuation)
+        }
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            rollBack(tapInstalled: true)
+            throw error
+        }
+        player.play()
+        lock.withLockUnchecked { isStarted = true }
+    }
+
+    public func enqueue(_ pcm16: Data) async {
+        guard let buffer = PCM16.floatBuffer(fromPCM16: pcm16, format: playbackFormat) else { return }
+        lock.withLockUnchecked {
+            guard isStarted else { return }   // covers pre-start AND racing/after stop()
+            player.scheduleBuffer(buffer, completionHandler: nil)   // non-async overload: never await playback
+        }
+    }
+
+    public func flush() async {
+        lock.withLockUnchecked {
+            guard isStarted else { return }
+            // `stop()` discards all scheduled buffers — the instant barge-in cut — then re-arm for next.
+            player.stop()
+            player.play()
+        }
+    }
+
+    public func stop() async {
+        lock.withLockUnchecked {
+            guard isStarted else { return }   // idempotent: the runtime stops this as input, then as output
+            isStarted = false
+            player.stop()
+            // Halt the render thread BEFORE removing the tap so no tap block starts mid-teardown.
+            engine.stop()
+            engine.inputNode.removeTap(onBus: 0)
+            continuation.finish()
+        }
+    }
+}

--- a/swift/Tests/AgentSquadAudioTests/AudioIOSmokeTests.swift
+++ b/swift/Tests/AgentSquadAudioTests/AudioIOSmokeTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import Testing
 
@@ -46,6 +47,31 @@ import AgentSquad
     @Test func audioPlaybackConstructsAcrossConfigurations() {
         _ = AudioPlayback(sessionPolicy: .external)
         _ = AudioPlayback(sessionPolicy: .managed, configureEngine: { _ in })
+    }
+
+    @Test func voiceProcessedAudioIOServesBothRoles() {
+        let io = VoiceProcessedAudioIO()
+        let input: any AudioInput = io
+        let output: any AudioOutput = io
+        _ = input.frames
+        _ = output
+        _ = VoiceProcessedAudioIO(voiceProcessing: .init(duckingLevel: .min), sessionPolicy: .external, configureEngine: { _ in })
+    }
+
+    @Test func voiceProcessedAudioIOIsInertBeforeStart() async {
+        // enqueue/flush/stop before start must be safe no-ops (the runtime can race teardown).
+        let io = VoiceProcessedAudioIO()
+        await io.enqueue(Data([0x00, 0x00]))
+        await io.flush()
+        await io.stop()
+    }
+
+    @Test func pcm16FloatBufferMatchesFloatSamples() {
+        let format = AVAudioFormat(standardFormatWithSampleRate: 24_000, channels: 1)!
+        let buffer = PCM16.floatBuffer(fromPCM16: Data([0x00, 0x00, 0xFF, 0x7F, 0x00, 0x80]), format: format)
+        #expect(buffer?.frameLength == 3)
+        #expect(buffer?.floatChannelData?[0][2] == -1.0)
+        #expect(PCM16.floatBuffer(fromPCM16: Data(), format: format) == nil)
     }
 
     @Test func pcm16ToFloatScalingAndEndianness() {

--- a/swift/Tests/AgentSquadAudioTests/AudioIOSmokeTests.swift
+++ b/swift/Tests/AgentSquadAudioTests/AudioIOSmokeTests.swift
@@ -22,6 +22,30 @@ import AgentSquad
     @Test func micCaptureErrorIsEquatable() {
         #expect(MicCaptureError.permissionDenied == .permissionDenied)
         #expect(MicCaptureError.permissionDenied != .converterUnavailable)
+        #expect(MicCaptureError.voiceProcessingUnavailable("x") == .voiceProcessingUnavailable("x"))
+        #expect(MicCaptureError.voiceProcessingUnavailable("x") != .voiceProcessingUnavailable("y"))
+    }
+
+    @Test func voiceProcessingDefaults() {
+        #expect(VoiceProcessing.default == VoiceProcessing())
+        #expect(VoiceProcessing.default.automaticGainControl)
+        #expect(VoiceProcessing.default.duckingLevel == .default)
+        #expect(VoiceProcessing(automaticGainControl: false, duckingLevel: .min) != .default)
+    }
+
+    @Test func micCaptureConstructsAcrossConfigurations() {
+        // Raw capture, external session, engine hook — constructing must not touch hardware.
+        _ = MicCapture(voiceProcessing: nil)
+        _ = MicCapture(sessionPolicy: .external, configureEngine: { _ in })
+        _ = MicCapture(voiceProcessing: .init(automaticGainControl: false, duckingLevel: .max))
+        #if os(iOS)
+        _ = MicCapture(sessionPolicy: .custom { _ in })
+        #endif
+    }
+
+    @Test func audioPlaybackConstructsAcrossConfigurations() {
+        _ = AudioPlayback(sessionPolicy: .external)
+        _ = AudioPlayback(sessionPolicy: .managed, configureEngine: { _ in })
     }
 
     @Test func pcm16ToFloatScalingAndEndianness() {


### PR DESCRIPTION
Raw capture let speaker output leak into the mic and self-interrupt the assistant. MicCapture now uses the Voice-Processing I/O unit by default; adds VoiceProcessing options, AudioSessionPolicy, and a configureEngine hook on both audio classes.

Refs #559

<!-- markdownlint-disable MD041 MD043 -->
## Issue Link (REQUIRED)
<!-- This PR must be linked to an issue. PRs without a linked issue will not be merged. -->
Fixes #<!-- Add issue number here (e.g., Fixes #123) -->

## Summary
### Changes
<!-- Please provide a summary of what's being changed -->

### User experience
<!-- Please share what the user experience looks like before and after this change -->

## Checklist
If your change doesn't seem to apply, please leave them unchecked.
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] I have linked this PR to an existing issue (required)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:
* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)
</details>

## Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.