### PR TITLE
fix(swift): send conversation.item.truncate on barge-in

### DIFF
--- a/docs/src/content/docs/swift/audio/built-in/audio-playback.md
+++ b/docs/src/content/docs/swift/audio/built-in/audio-playback.md
@@ -40,7 +40,10 @@ public func start()                 async throws  // attaches player node, start
 public func enqueue(_ pcm16: Data)  async          // schedules one PCM16 frame for playback
 public func flush()                 async          // discards all scheduled/playing buffers — instant barge-in cut
 public func stop()                  async          // stops player and engine
+public func playedMilliseconds()    async -> Double?  // ms actually played of the current burst (survives flush)
 ```
+
+`playedMilliseconds()` is measured from the player's `.dataPlayedBack` buffer callbacks and feeds the session's `conversation.item.truncate` on barge-in — after a `flush()` it still reports the interrupted burst's played total until new audio starts.
 
 `start()` is idempotent — a second call before `stop()` is a no-op.
 

--- a/docs/src/content/docs/swift/audio/built-in/voice-processed-audio-io.md
+++ b/docs/src/content/docs/swift/audio/built-in/voice-processed-audio-io.md
@@ -50,7 +50,10 @@ public func start() async throws        // both roles; idempotent
 public func enqueue(_ pcm16: Data) async // AudioOutput — schedule one frame
 public func flush() async                // AudioOutput — instant barge-in cut
 public func stop()  async                // both roles; idempotent
+public func playedMilliseconds() async -> Double?  // ms actually played of the current burst (survives flush)
 ```
+
+`playedMilliseconds()` feeds the session's `conversation.item.truncate` on barge-in, keeping the server's context aligned with what the user actually heard.
 
 `start()` and `stop()` are **idempotent** — `RealtimeRuntime` calls each twice on the same instance (once through the `AudioOutput` role, once through `AudioInput`), and the second call is a no-op. `enqueue`/`flush` before `start()` or after `stop()` are safe no-ops. One instance serves **one session**: `stop()` finishes the `frames` stream for good — create a new instance to start again.
 

--- a/docs/src/content/docs/swift/audio/custom.md
+++ b/docs/src/content/docs/swift/audio/custom.md
@@ -96,6 +96,8 @@ actor RecordingAudioOutput: AudioOutput {
 `RecordingAudioOutput` is declared as an `actor`, which satisfies `Sendable` implicitly. For a `class`-based conformance — like `MicCapture` and `AudioPlayback` — mark it `@unchecked Sendable` and serialise access yourself (or route all calls through a single `Task`).
 :::
 
+`playedMilliseconds()` is not implemented above — the protocol defaults it to `nil`, which skips barge-in truncation (`conversation.item.truncate`) and changes nothing else. Implement it (ms actually played of the current burst, surviving `flush()`) if your output plays audio for real and you want the model's context to keep only what the user heard.
+
 ---
 
 ## Wiring a custom implementation

--- a/docs/src/content/docs/swift/audio/overview.md
+++ b/docs/src/content/docs/swift/audio/overview.md
@@ -39,10 +39,13 @@ public protocol AudioOutput: Sendable {
     func enqueue(_ pcm16: Data) async
     func flush()                async
     func stop()                 async
+    func playedMilliseconds()   async -> Double?   // default implementation returns nil
 }
 ```
 
 `enqueue` schedules one PCM16 frame without waiting for it to finish playing — implementations must not serialize to real-time playback speed. `flush` is the barge-in primitive: it discards all queued or in-flight audio instantly.
+
+`playedMilliseconds` reports how much of the current playback burst was actually played; the session uses it on barge-in to send `conversation.item.truncate`, keeping the server's context aligned with what the user heard (the OpenAI WebSocket interruption procedure). It must survive `flush()` — the session samples it right after the cut. A protocol extension defaults it to `nil`, in which case truncation is skipped and everything else works unchanged.
 
 ---
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -303,6 +303,10 @@ final class MyCapture: AudioInput { /* frames, start(), stop() */ }
 let runtime = RealtimeRuntime(session: assistant, input: MyCapture(), output: AudioPlayback())
 ```
 
+A custom `AudioOutput` can also implement `playedMilliseconds()` (defaults to `nil`) — the
+session uses it to send `conversation.item.truncate` on barge-in, so the model's context only
+keeps what the user actually heard. The built-in outputs measure this automatically.
+
 > **Validate on a real device.** The simulator performs no echo cancellation at all, so AEC can't
 > be tested there. Expect voice-processed audio to sound "call-like" and slightly quieter — use
 > `duckingLevel: .min` to compensate. Never enable voice processing on the playback engine; it

--- a/swift/SKILL.md
+++ b/swift/SKILL.md
@@ -124,6 +124,13 @@ signatures live in `Sources/AgentSquad/`.
   pattern-scrub PII — supply a custom `Redactor` for that.
 - **Realtime** is a peer runtime, not an agent; its `events` stream is non-throwing; needs
   `NSMicrophoneUsageDescription`; always `stop()`.
+- **Barge-in truncation**: on interrupt the session sends `conversation.item.truncate` so the
+  server drops the unheard audio + transcript from context (OpenAI docs' WebSocket procedure).
+  Automatic when wired by `RealtimeRuntime` with the built-in outputs; a custom `AudioOutput`
+  gets it by implementing `playedMilliseconds()` (protocol default returns `nil` → truncation
+  is skipped, everything else works). Applies to in-band spoken replies only — the grounded
+  presenter is out-of-band (`conversation: "none"`), its items never enter the conversation,
+  so interrupting it deliberately sends no truncate.
 - **Voice processing (AEC)**: on by default; if it can't be enabled `start()` throws
   `.voiceProcessingUnavailable` (degrade deliberately with `MicCapture(voiceProcessing: nil)`).
   For guaranteed echo cancellation use `VoiceProcessedAudioIO` and pass the **same instance** as

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/AudioIO.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/AudioIO.swift
@@ -19,4 +19,13 @@ public protocol AudioOutput: Sendable {
     /// Drop all queued/playing audio immediately (barge-in cut).
     func flush() async
     func stop() async
+    /// Milliseconds actually played of the current playback burst (a burst starts when audio is
+    /// enqueued onto an empty queue), or `nil` when the implementation can't measure playback.
+    /// Must survive `flush()` — the session samples it right after a barge-in cut to send
+    /// `conversation.item.truncate`. Default: `nil` (truncation is skipped).
+    func playedMilliseconds() async -> Double?
+}
+
+public extension AudioOutput {
+    func playedMilliseconds() async -> Double? { nil }
 }

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/AudioTruncation.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/AudioTruncation.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Per-turn bookkeeping for barge-in truncation (`conversation.item.truncate`): which assistant
+/// audio item is playing and how many milliseconds of it the server has sent. Compared against the
+/// playback clock's *played* milliseconds to build a truncate frame that never exceeds the item's
+/// actual duration (the API errors on `audio_end_ms` greater than the audio's length).
+struct AudioTruncationState {
+    private(set) var itemId: String?
+    private(set) var receivedMs: Double = 0
+    // Audio played before this item within the same playback burst (a tool→continue turn can
+    // speak several items back-to-back without the queue draining) — subtracted from the burst
+    // clock so `audio_end_ms` is per-item, never inflated by a predecessor's playback.
+    private(set) var itemStartMs: Double = 0
+
+    /// Record one relayed audio delta. A new `itemId` restarts the received counter and moves
+    /// the burst offset past the previous item's audio.
+    mutating func record(itemId: String, pcm16ByteCount: Int, sampleRate: Int) {
+        guard !itemId.isEmpty, sampleRate > 0 else { return }
+        if itemId != self.itemId {
+            itemStartMs += receivedMs
+            self.itemId = itemId
+            receivedMs = 0
+        }
+        // PCM16 mono: 2 bytes per sample.
+        receivedMs += Double(pcm16ByteCount) / 2 / Double(sampleRate) * 1_000
+    }
+
+    mutating func reset() {
+        itemId = nil
+        receivedMs = 0
+        itemStartMs = 0
+    }
+
+    /// The truncate frame for a barge-in, or `nil` when there is nothing to truncate: no item
+    /// relayed, no playback measurement, or nothing of THIS item unplayed. `played` can go
+    /// negative when the burst drained between items (the clock restarted) and can exceed
+    /// `receivedMs` on a stale clock — both skip rather than send a value the server could
+    /// reject (`audio_end_ms` beyond the actual duration errors) or that over-reports.
+    func truncateFrame(playedMs: Double?) -> String? {
+        guard let itemId, let playedMs else { return nil }
+        let played = playedMs - itemStartMs
+        guard played >= 0, played < receivedMs else { return nil }
+        return RealtimeWire.truncateItem(itemId: itemId, audioEndMs: Int(played))
+    }
+}

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
@@ -158,8 +158,8 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
         let wasActive = presenterActive
         presenterActive = false   // clear before the await so an interleaved frame sees the final state
         if wasActive {
-            // Barge-in step 3 (WebSocket): tell the server how much was actually heard so it drops
-            // the unplayed audio + transcript from context.
+            // Barge-in steps 2+3 (WebSocket): the clock closure reports what was heard and cuts
+            // playback; the truncate then lets the server drop the unplayed audio + transcript.
             if let clock = playbackClock, let frame = truncation.truncateFrame(playedMs: await clock()) {
                 try? await transport.send(frame)
             }

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
@@ -45,6 +45,13 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
     private var presenterId: String?
     private var presenterResponses: Set<String> = []
     private var presenterActive = false
+    // Barge-in truncation: which audio item is playing + how much was sent, vs. the runtime's
+    // played-ms clock. NOT cleared by `resetTurn` — `interrupt()` reads it after resetting the turn.
+    // Only the in-band `direct` reply is truncatable: the presenter is out-of-band
+    // (`conversation: "none"`), its items never enter the conversation, and truncating one errors.
+    private var truncation = AudioTruncationState()
+    private var spokenResponseIsInBand = false
+    private var playbackClock: (@Sendable () async -> Double?)?
     // The turn's user question + spoken reply, captured for persistence. They survive `resetTurn`
     // because present()/speakDirectly() reset before the presenter speaks (the reset-before-await).
     private var pendingUserText = ""
@@ -111,6 +118,9 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
     public func sendAudio(_ pcm16: Data) async {
         try? await transport.send(RealtimeWire.appendAudio(pcm16.base64EncodedString()))
     }
+    public func setPlaybackClock(_ playedMilliseconds: @escaping @Sendable () async -> Double?) async {
+        playbackClock = playedMilliseconds
+    }
 
     // MARK: - Session seams
 
@@ -148,8 +158,14 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
         let wasActive = presenterActive
         presenterActive = false   // clear before the await so an interleaved frame sees the final state
         if wasActive {
+            // Barge-in step 3 (WebSocket): tell the server how much was actually heard so it drops
+            // the unplayed audio + transcript from context.
+            if let clock = playbackClock, let frame = truncation.truncateFrame(playedMs: await clock()) {
+                try? await transport.send(frame)
+            }
             try? await transport.send(RealtimeWire.cancelResponse())
         }
+        truncation.reset()
         // Always emit, even when nothing was playing (a fresh-turn speech_started also lands here) —
         // the consumer treats a flush-when-idle as a no-op.
         emit(.audioDone(interrupted: true))
@@ -177,8 +193,13 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
             if responseId == presenterId { emit(.presenterText(text, final: false)) } else { agentText += text }
         case .outputTextDone(let responseId, let text):
             if responseId == presenterId { replyText = text; emit(.presenterText(text, final: true)) }
-        case .audioDelta(let responseId, let base64):
-            if responseId == presenterId, let data = Data(base64Encoded: base64) { emit(.audio(data)) }
+        case .audioDelta(let responseId, let itemId, let base64):
+            if responseId == presenterId, let data = Data(base64Encoded: base64) {
+                if spokenResponseIsInBand {   // presenter is out-of-band — nothing to truncate server-side
+                    truncation.record(itemId: itemId, pcm16ByteCount: data.count, sampleRate: sampleRate)
+                }
+                emit(.audio(data))
+            }
         case .audioTranscriptDelta(let responseId, let text):
             if responseId == presenterId, modality.output == .audioAndText { emit(.presenterText(text, final: false)) }
         case .audioTranscriptDone(let responseId, let text):
@@ -196,6 +217,7 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
             if (role == "presenter" || role == "direct"), !id.isEmpty {
                 presenterResponses.insert(id)
                 presenterId = id
+                spokenResponseIsInBand = role == "direct"
             }
         case .responseDone(let id, let usage):
             await responseDone(id, usage: usage)
@@ -211,6 +233,7 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
             if id == presenterId {   // the response we're hearing finished cleanly
                 presenterId = nil
                 presenterActive = false
+                truncation.reset()   // clean finish — nothing left to truncate
                 let (user, reply) = (pendingUserText, replyText)   // snapshot + clear before the store await
                 // Record the spoken answer as a `presenter` generation (question in, reply out, presenter
                 // usage) under the turn, then close the turn. The gatherer's tool calls show as the turn's

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
@@ -46,6 +46,10 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
     private var liveResponses: Set<String> = []
     private var currentResponseId: String?
     private var isSpeaking = false
+    // Barge-in truncation: which audio item is playing + how much was sent, vs. the runtime's
+    // played-ms clock. NOT cleared by `resetTurn` — `interrupt()` reads it after resetting the turn.
+    private var truncation = AudioTruncationState()
+    private var playbackClock: (@Sendable () async -> Double?)?
 
     var sessionSpan: (any SpanHandle)?
     var turnSpan: (any SpanHandle)?
@@ -100,6 +104,9 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
     public func sendAudio(_ pcm16: Data) async {
         try? await transport.send(RealtimeWire.appendAudio(pcm16.base64EncodedString()))
     }
+    public func setPlaybackClock(_ playedMilliseconds: @escaping @Sendable () async -> Double?) async {
+        playbackClock = playedMilliseconds
+    }
 
     // MARK: - Session seams
 
@@ -140,8 +147,14 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         let wasSpeaking = isSpeaking
         isSpeaking = false             // clear before the await so an interleaved frame sees the final state
         if wasSpeaking {
+            // Barge-in step 3 (WebSocket): tell the server how much was actually heard so it drops
+            // the unplayed audio + transcript from context.
+            if let clock = playbackClock, let frame = truncation.truncateFrame(playedMs: await clock()) {
+                try? await transport.send(frame)
+            }
             try? await transport.send(RealtimeWire.cancelResponse())
         }
+        truncation.reset()
         emit(.audioDone(interrupted: true))
         emit(.state(.listening))
     }
@@ -167,8 +180,11 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
             if responseId == currentResponseId { emit(.presenterText(text, final: false)) }
         case .outputTextDone(let responseId, let text):
             if responseId == currentResponseId { replyText = text; emit(.presenterText(text, final: true)) }
-        case .audioDelta(let responseId, let base64):
-            if responseId == currentResponseId, let data = Data(base64Encoded: base64) { emit(.audio(data)) }
+        case .audioDelta(let responseId, let itemId, let base64):
+            if responseId == currentResponseId, let data = Data(base64Encoded: base64) {
+                truncation.record(itemId: itemId, pcm16ByteCount: data.count, sampleRate: sampleRate)
+                emit(.audio(data))
+            }
         case .audioTranscriptDelta(let responseId, let text):
             if responseId == currentResponseId, modality.output == .audioAndText { emit(.presenterText(text, final: false)) }
         case .audioTranscriptDone(let responseId, let text):
@@ -209,6 +225,7 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         guard id == currentResponseId else { return }
         currentResponseId = nil
         isSpeaking = false
+        truncation.reset()   // clean finish — nothing left to truncate
         // Snapshot the pair before the store await — a next turn interleaving during it (e.g. a typed
         // `sendText`) would otherwise have its captured state wiped by resetTurn.
         let (user, reply) = (userText, replyText)

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
@@ -147,8 +147,8 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         let wasSpeaking = isSpeaking
         isSpeaking = false             // clear before the await so an interleaved frame sees the final state
         if wasSpeaking {
-            // Barge-in step 3 (WebSocket): tell the server how much was actually heard so it drops
-            // the unplayed audio + transcript from context.
+            // Barge-in steps 2+3 (WebSocket): the clock closure reports what was heard and cuts
+            // playback; the truncate then lets the server drop the unplayed audio + transcript.
             if let clock = playbackClock, let frame = truncation.truncateFrame(playedMs: await clock()) {
                 try? await transport.send(frame)
             }

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeRuntime.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeRuntime.swift
@@ -27,6 +27,9 @@ public actor RealtimeRuntime {
     }
 
     public func start() async throws {
+        // Wire the output's played-ms clock into the session so barge-in can send
+        // `conversation.item.truncate` (WebSocket transports: the client manages playback).
+        await session.setPlaybackClock { [output] in await output.playedMilliseconds() }
         try await output.start()
         try await session.start()
         try await input.start()

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeRuntime.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeRuntime.swift
@@ -29,7 +29,17 @@ public actor RealtimeRuntime {
     public func start() async throws {
         // Wire the output's played-ms clock into the session so barge-in can send
         // `conversation.item.truncate` (WebSocket transports: the client manages playback).
-        await session.setPlaybackClock { [output] in await output.playedMilliseconds() }
+        // Sample THEN cut: a flush re-arms the burst, so a stale pump `enqueue` racing in after
+        // it would zero the total — sampling first makes the measurement immune to that, and the
+        // cut still lands here, before the session sends the truncate frame (the docs' stop-
+        // before-truncate). On server-VAD barge-in this is the earliest possible cut (the
+        // session hasn't emitted `.audioDone` yet); on app-initiated interrupt the runtime
+        // already flushed and this one is an idempotent repeat.
+        await session.setPlaybackClock { [output] in
+            let played = await output.playedMilliseconds()
+            await output.flush()
+            return played
+        }
         try await output.start()
         try await session.start()
         try await input.start()
@@ -51,9 +61,9 @@ public actor RealtimeRuntime {
 
     /// Explicit barge-in (e.g. a stop button) — cuts playback and stops the in-flight response.
     public func interrupt() async {
-        // Flush eagerly for latency (don't wait the server round-trip). The session's own
-        // `interrupt()` then emits `.audioDone(interrupted: true)`, which `route` flushes again — a
-        // harmless idempotent repeat that also covers server-initiated barge-in. Keep both.
+        // Flush eagerly for latency, and because a custom session without a playback clock never
+        // flushes on its own. The session's clock closure (sample + flush) and the
+        // `.audioDone(interrupted: true)` route are idempotent repeats. Keep all three.
         await output.flush()
         await session.interrupt()
     }

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeWire.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeWire.swift
@@ -141,6 +141,20 @@ enum RealtimeWire {
         frame(["type": .string("response.cancel")])
     }
 
+    /// `conversation.item.truncate` — barge-in step 3 (WebSocket transports manage playback, so the
+    /// client must tell the server how much was actually heard; the server drops the unplayed audio
+    /// AND its transcript). `content_index` is always `0` per the API reference. `audioEndMs` is
+    /// inclusive and MUST NOT exceed the item's actual audio duration (the server errors) — callers
+    /// enforce that via `AudioTruncationState`.
+    static func truncateItem(itemId: String, audioEndMs: Int) -> String {
+        frame([
+            "type": .string("conversation.item.truncate"),
+            "item_id": .string(itemId),
+            "content_index": .int(0),
+            "audio_end_ms": .int(audioEndMs),
+        ])
+    }
+
     // MARK: - Inbound
 
     /// Decode one inbound frame to a `ServerEvent`, or `nil` for events we don't handle.
@@ -238,7 +252,7 @@ enum RealtimeWire {
             return .audioTranscriptDone(responseId: event.responseId ?? "", text: event.transcript ?? "")
         }
         if type.hasSuffix("audio.delta") {
-            return .audioDelta(responseId: event.responseId ?? "", base64: event.delta ?? "")
+            return .audioDelta(responseId: event.responseId ?? "", itemId: event.itemId ?? "", base64: event.delta ?? "")
         }
         if type.hasSuffix("output_text.delta") || type == "response.text.delta" {
             return .outputTextDelta(responseId: event.responseId ?? "", text: event.delta ?? "")
@@ -255,6 +269,7 @@ enum RealtimeWire {
         let transcript: String?
         let text: String?
         let responseId: String?
+        let itemId: String?
         let callId: String?
         let name: String?
         let arguments: String?
@@ -265,6 +280,7 @@ enum RealtimeWire {
         enum CodingKeys: String, CodingKey {
             case type, delta, transcript, text, name, arguments, response, item, error
             case responseId = "response_id"
+            case itemId = "item_id"
             case callId = "call_id"
         }
 
@@ -320,7 +336,7 @@ enum ServerEvent: Sendable, Equatable {
     case functionCallArguments(responseId: String, callId: String, name: String?, arguments: String)
     case outputTextDelta(responseId: String, text: String)
     case outputTextDone(responseId: String, text: String)
-    case audioDelta(responseId: String, base64: String)
+    case audioDelta(responseId: String, itemId: String, base64: String)
     case audioTranscriptDelta(responseId: String, text: String)
     case audioTranscriptDone(responseId: String, text: String)
     case responseCreated(id: String, role: String?)

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
@@ -81,4 +81,14 @@ public protocol VoiceAssistant: Sendable {
     var events: AsyncStream<RealtimeEvent> { get }
     /// Close the connection.
     func stop() async
+    /// Install a playback clock: how many milliseconds of assistant audio were actually played
+    /// (`nil` = unmeasurable). With WebSocket transports the client manages playback, so on
+    /// barge-in the session uses this to send `conversation.item.truncate` — keeping the server's
+    /// context aligned with what the user heard. `RealtimeRuntime` installs it at `start()`.
+    /// Optional: the default is a no-op, and sessions without a clock skip truncation.
+    func setPlaybackClock(_ playedMilliseconds: @escaping @Sendable () async -> Double?) async
+}
+
+public extension VoiceAssistant {
+    func setPlaybackClock(_ playedMilliseconds: @escaping @Sendable () async -> Double?) async {}
 }

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
@@ -81,11 +81,12 @@ public protocol VoiceAssistant: Sendable {
     var events: AsyncStream<RealtimeEvent> { get }
     /// Close the connection.
     func stop() async
-    /// Install a playback clock: how many milliseconds of assistant audio were actually played
-    /// (`nil` = unmeasurable). With WebSocket transports the client manages playback, so on
-    /// barge-in the session uses this to send `conversation.item.truncate` — keeping the server's
-    /// context aligned with what the user heard. `RealtimeRuntime` installs it at `start()`.
-    /// Optional: the default is a no-op, and sessions without a clock skip truncation.
+    /// Install a playback clock the session invokes on barge-in: the closure reports how many
+    /// milliseconds of assistant audio were actually played (`nil` = unmeasurable) and CUTS
+    /// playback before returning — so by the time the session sends `conversation.item.truncate`
+    /// the audio has stopped (the OpenAI procedure: stop playback, note how much was played,
+    /// truncate). `RealtimeRuntime` installs it at `start()` as sample + flush. Optional: the
+    /// default is a no-op, and sessions without a clock skip truncation.
     func setPlaybackClock(_ playedMilliseconds: @escaping @Sendable () async -> Double?) async
 }
 

--- a/swift/Sources/AgentSquadAudio/AudioPlayback.swift
+++ b/swift/Sources/AgentSquadAudio/AudioPlayback.swift
@@ -1,19 +1,22 @@
 import AVFoundation
 import AgentSquad
+import os
 
 /// `AudioOutput` over `AVAudioEngine` + `AVAudioPlayerNode`: schedules incoming PCM16 @ 24 kHz frames
 /// (converted to float) for playback; `flush` stops and clears the queue for an instant barge-in cut.
 ///
-/// `@unchecked Sendable`: not safe to call concurrently — callers must serialize. `RealtimeRuntime`
-/// satisfies this by driving every method from its single event pump, so the engine/player are
-/// never touched concurrently.
+/// `@unchecked Sendable`: `enqueue`/`flush`/`stop` are serialized by an internal unfair lock —
+/// the session's barge-in playback clock flushes from its own task, concurrent with the runtime
+/// pump's `enqueue`. `start()` must not be called concurrently with itself (the runtime awaits
+/// it before any pump runs).
 public final class AudioPlayback: AudioOutput, @unchecked Sendable {
     private let engine = AVAudioEngine()
     private let player = AVAudioPlayerNode()
     private let format: AVAudioFormat
     private let sessionPolicy: AudioSessionPolicy
     private let configureEngine: (@Sendable (AVAudioEngine) throws -> Void)?
-    private let clock = PlaybackClock()
+    private let clock = PlaybackClock()   // its own lock; callbacks never take `lock`
+    private let lock = OSAllocatedUnfairLock()
     private var isStarted = false
 
     /// `configureEngine` runs after the player is attached/connected, before the engine starts —
@@ -30,7 +33,7 @@ public final class AudioPlayback: AudioOutput, @unchecked Sendable {
     }
 
     public func start() async throws {
-        guard !isStarted else { return }   // start-once: a second engine.attach(player) would crash
+        guard lock.withLockUnchecked({ !isStarted }) else { return }   // start-once: a second engine.attach(player) would crash
         #if os(iOS)
         try VoiceAudioSession.activate(policy: sessionPolicy)
         #endif
@@ -45,7 +48,7 @@ public final class AudioPlayback: AudioOutput, @unchecked Sendable {
             throw error
         }
         player.play()
-        isStarted = true
+        lock.withLockUnchecked { isStarted = true }
     }
 
     public func enqueue(_ pcm16: Data) async {
@@ -57,9 +60,11 @@ public final class AudioPlayback: AudioOutput, @unchecked Sendable {
     /// playback completion — that would serialize enqueue to real-time playback speed).
     private func schedule(_ buffer: AVAudioPCMBuffer) {
         let durationMs = Double(buffer.frameLength) / format.sampleRate * 1_000
-        let token = clock.willSchedule()
-        player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [clock] _ in
-            clock.completed(durationMs: durationMs, token: token)
+        lock.withLockUnchecked {
+            let token = clock.willSchedule()
+            player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [clock] _ in
+                clock.completed(durationMs: durationMs, token: token)
+            }
         }
     }
 
@@ -67,16 +72,20 @@ public final class AudioPlayback: AudioOutput, @unchecked Sendable {
         // `stop()` discards all scheduled buffers — the instant barge-in cut — then re-arm for next.
         // The clock keeps its played total (voiding only pending buffers) so the session can still
         // sample it for `conversation.item.truncate`.
-        clock.flushed()
-        player.stop()
-        player.play()
+        lock.withLockUnchecked {
+            clock.flushed()
+            player.stop()
+            player.play()
+        }
     }
 
     public func stop() async {
-        player.stop()
-        engine.stop()
-        clock.reset()
-        isStarted = false
+        lock.withLockUnchecked {
+            player.stop()
+            engine.stop()
+            clock.reset()
+            isStarted = false
+        }
     }
 
     public func playedMilliseconds() async -> Double? {

--- a/swift/Sources/AgentSquadAudio/AudioPlayback.swift
+++ b/swift/Sources/AgentSquadAudio/AudioPlayback.swift
@@ -13,6 +13,7 @@ public final class AudioPlayback: AudioOutput, @unchecked Sendable {
     private let format: AVAudioFormat
     private let sessionPolicy: AudioSessionPolicy
     private let configureEngine: (@Sendable (AVAudioEngine) throws -> Void)?
+    private let clock = PlaybackClock()
     private var isStarted = false
 
     /// `configureEngine` runs after the player is attached/connected, before the engine starts —
@@ -55,11 +56,18 @@ public final class AudioPlayback: AudioOutput, @unchecked Sendable {
     /// Sync hand-off so the non-async `scheduleBuffer` overload is selected (we must NOT await
     /// playback completion — that would serialize enqueue to real-time playback speed).
     private func schedule(_ buffer: AVAudioPCMBuffer) {
-        player.scheduleBuffer(buffer, completionHandler: nil)
+        let durationMs = Double(buffer.frameLength) / format.sampleRate * 1_000
+        let token = clock.willSchedule()
+        player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [clock] _ in
+            clock.completed(durationMs: durationMs, token: token)
+        }
     }
 
     public func flush() async {
         // `stop()` discards all scheduled buffers — the instant barge-in cut — then re-arm for next.
+        // The clock keeps its played total (voiding only pending buffers) so the session can still
+        // sample it for `conversation.item.truncate`.
+        clock.flushed()
         player.stop()
         player.play()
     }
@@ -67,7 +75,12 @@ public final class AudioPlayback: AudioOutput, @unchecked Sendable {
     public func stop() async {
         player.stop()
         engine.stop()
+        clock.reset()
         isStarted = false
+    }
+
+    public func playedMilliseconds() async -> Double? {
+        clock.milliseconds()
     }
 
     private func makeBuffer(_ data: Data) -> AVAudioPCMBuffer? {

--- a/swift/Sources/AgentSquadAudio/PlaybackClock.swift
+++ b/swift/Sources/AgentSquadAudio/PlaybackClock.swift
@@ -1,0 +1,66 @@
+import AVFoundation
+import os
+
+/// Played-milliseconds accounting for `AudioOutput.playedMilliseconds()` — feeds the session's
+/// `conversation.item.truncate` on barge-in. Buffers report back through the player's
+/// `.dataPlayedBack` completion callbacks; a *burst* is one continuous run of playback starting
+/// on an empty queue (in practice: one spoken response).
+///
+/// `flush()` (barge-in) voids the pending buffers' callbacks — `AVAudioPlayerNode.stop()` fires
+/// them for *unplayed* buffers too — but KEEPS the played total: the session samples it right
+/// after the cut. The total resets when the next burst begins.
+///
+/// If the queue drains *mid-response* (a stall — rare, since the server sends audio faster than
+/// realtime), the resume starts a new burst and the total restarts. Deliberately conservative:
+/// truncation then under-reports played audio, never claiming the user heard something they
+/// didn't (`audio_end_ms` beyond the played point is the harmful direction).
+///
+/// Sendable via `OSAllocatedUnfairLock`; completion callbacks arrive on AVFoundation's internal
+/// queue and never touch the owning class's state, so no lock-ordering hazard with `stop()`.
+final class PlaybackClock: Sendable {
+    private struct State {
+        var playedMs = 0.0
+        var pending = 0
+        var generation = 0
+        var idle = true   // queue ran empty → the next schedule starts a new burst
+    }
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    /// Call before scheduling a buffer; pass the returned token to `completed`.
+    func willSchedule() -> Int {
+        state.withLock {
+            if $0.idle { $0.playedMs = 0; $0.idle = false }
+            $0.pending += 1
+            return $0.generation
+        }
+    }
+
+    /// From the buffer's `.dataPlayedBack` completion callback.
+    func completed(durationMs: Double, token: Int) {
+        state.withLock {
+            guard token == $0.generation else { return }   // voided by flush — stop() fires these early
+            $0.playedMs += durationMs
+            $0.pending -= 1
+            if $0.pending == 0 { $0.idle = true }
+        }
+    }
+
+    /// Barge-in cut: void pending callbacks, keep the played total for sampling.
+    func flushed() {
+        state.withLock {
+            $0.generation += 1
+            $0.pending = 0
+            $0.idle = true
+        }
+    }
+
+    func reset() {
+        // Bump the generation, don't rewind it — `player.stop()` fires pending callbacks
+        // asynchronously and a rewound generation would let them pass the token guard.
+        state.withLock { $0 = State(generation: $0.generation + 1) }
+    }
+
+    func milliseconds() -> Double {
+        state.withLock { $0.playedMs }
+    }
+}

--- a/swift/Sources/AgentSquadAudio/VoiceProcessedAudioIO.swift
+++ b/swift/Sources/AgentSquadAudio/VoiceProcessedAudioIO.swift
@@ -31,6 +31,7 @@ public final class VoiceProcessedAudioIO: AudioInput, AudioOutput, @unchecked Se
     private let sessionPolicy: AudioSessionPolicy
     private let configureEngine: (@Sendable (AVAudioEngine) throws -> Void)?
     private let lock = OSAllocatedUnfairLock()
+    private let clock = PlaybackClock()   // its own lock; callbacks never take `lock`
     private var isStarted = false   // guarded by `lock`
 
     /// `voiceProcessing` is non-optional here — raw capture defeats this class's purpose; use
@@ -122,16 +123,25 @@ public final class VoiceProcessedAudioIO: AudioInput, AudioOutput, @unchecked Se
 
     public func enqueue(_ pcm16: Data) async {
         guard let buffer = PCM16.floatBuffer(fromPCM16: pcm16, format: playbackFormat) else { return }
+        let durationMs = Double(buffer.frameLength) / playbackFormat.sampleRate * 1_000
         lock.withLockUnchecked {
             guard isStarted else { return }   // covers pre-start AND racing/after stop()
-            player.scheduleBuffer(buffer, completionHandler: nil)   // non-async overload: never await playback
+            let token = clock.willSchedule()
+            // Handler-based (non-async) overload: never await playback. `.dataPlayedBack` feeds the
+            // played-ms clock behind `playedMilliseconds()`.
+            player.scheduleBuffer(buffer, completionCallbackType: .dataPlayedBack) { [clock] _ in
+                clock.completed(durationMs: durationMs, token: token)
+            }
         }
     }
 
     public func flush() async {
         lock.withLockUnchecked {
             guard isStarted else { return }
-            // `stop()` discards all scheduled buffers — the instant barge-in cut — then re-arm for next.
+            // `stop()` discards all scheduled buffers — the instant barge-in cut — then re-arm for
+            // next. The clock keeps its played total (voiding only pending buffers) so the session
+            // can still sample it for `conversation.item.truncate`.
+            clock.flushed()
             player.stop()
             player.play()
         }
@@ -145,7 +155,12 @@ public final class VoiceProcessedAudioIO: AudioInput, AudioOutput, @unchecked Se
             // Halt the render thread BEFORE removing the tap so no tap block starts mid-teardown.
             engine.stop()
             engine.inputNode.removeTap(onBus: 0)
+            clock.reset()
             continuation.finish()
         }
+    }
+
+    public func playedMilliseconds() async -> Double? {
+        clock.milliseconds()
     }
 }

--- a/swift/Tests/AgentSquadAudioTests/AudioIOSmokeTests.swift
+++ b/swift/Tests/AgentSquadAudioTests/AudioIOSmokeTests.swift
@@ -87,6 +87,18 @@ import AgentSquad
         #expect(clock.milliseconds() == 40)   // the played total survives the flush for sampling
     }
 
+    @Test func staleEnqueueAfterFlushZeroesTheTotal() {
+        // Why the runtime's clock closure samples BEFORE it flushes: a flush re-arms the burst,
+        // and any stale enqueue racing in afterwards starts a new one, wiping the played total.
+        let clock = PlaybackClock()
+        let t = clock.willSchedule()
+        clock.completed(durationMs: 40, token: t)
+        clock.flushed()
+        #expect(clock.milliseconds() == 40)   // survives the flush…
+        _ = clock.willSchedule()              // …until a stale enqueue lands
+        #expect(clock.milliseconds() == 0)
+    }
+
     @Test func playbackClockUnderReportsAfterAMidResponseStall() {
         // Queue drains mid-response (stall) → the next buffer starts a new burst and the total
         // restarts. Deliberate: truncation then under-reports, which never claims unheard audio

--- a/swift/Tests/AgentSquadAudioTests/AudioIOSmokeTests.swift
+++ b/swift/Tests/AgentSquadAudioTests/AudioIOSmokeTests.swift
@@ -66,6 +66,66 @@ import AgentSquad
         await io.stop()
     }
 
+    @Test func playbackClockAccumulatesPlayedBuffers() {
+        let clock = PlaybackClock()
+        let t1 = clock.willSchedule()
+        let t2 = clock.willSchedule()
+        clock.completed(durationMs: 40, token: t1)
+        clock.completed(durationMs: 60, token: t2)
+        #expect(clock.milliseconds() == 100)
+    }
+
+    @Test func playbackClockSurvivesFlushAndVoidsPendingBuffers() {
+        // The realistic barge-in: deltas outpace playback, so the queue still holds buffers at the cut.
+        let clock = PlaybackClock()
+        let played = clock.willSchedule()
+        let pending = clock.willSchedule()   // still queued when the user barges in
+        clock.completed(durationMs: 40, token: played)
+        clock.flushed()
+        // player.stop() fires the pending buffer's callback too — it must not count.
+        clock.completed(durationMs: 500, token: pending)
+        #expect(clock.milliseconds() == 40)   // the played total survives the flush for sampling
+    }
+
+    @Test func playbackClockUnderReportsAfterAMidResponseStall() {
+        // Queue drains mid-response (stall) → the next buffer starts a new burst and the total
+        // restarts. Deliberate: truncation then under-reports, which never claims unheard audio
+        // was played (over-reporting is the server-error case).
+        let clock = PlaybackClock()
+        let t1 = clock.willSchedule()
+        clock.completed(durationMs: 40, token: t1)   // drained
+        let t2 = clock.willSchedule()                // stalled response resumes
+        clock.completed(durationMs: 10, token: t2)
+        #expect(clock.milliseconds() == 10)
+    }
+
+    @Test func playbackClockStartsANewBurstAfterDrainOrFlush() {
+        let clock = PlaybackClock()
+        let t1 = clock.willSchedule()
+        clock.completed(durationMs: 40, token: t1)         // queue drained → idle
+        let t2 = clock.willSchedule()                       // new burst → total resets
+        clock.completed(durationMs: 10, token: t2)
+        #expect(clock.milliseconds() == 10)
+
+        clock.flushed()                                     // barge-in → idle
+        let t3 = clock.willSchedule()
+        clock.completed(durationMs: 5, token: t3)
+        #expect(clock.milliseconds() == 5)
+    }
+
+    @Test func outputsExposeAPlayedClockAndInputsDefaultToNil() async {
+        // Pre-start: 0 from the built-ins (measured, nothing played), nil from the protocol default.
+        struct BareOutput: AudioOutput {
+            func start() async throws {}
+            func enqueue(_ pcm16: Data) async {}
+            func flush() async {}
+            func stop() async {}
+        }
+        #expect(await AudioPlayback().playedMilliseconds() == 0)
+        #expect(await VoiceProcessedAudioIO().playedMilliseconds() == 0)
+        #expect(await BareOutput().playedMilliseconds() == nil)
+    }
+
     @Test func pcm16FloatBufferMatchesFloatSamples() {
         let format = AVAudioFormat(standardFormatWithSampleRate: 24_000, channels: 1)!
         let buffer = PCM16.floatBuffer(fromPCM16: Data([0x00, 0x00, 0xFF, 0x7F, 0x00, 0x80]), format: format)

--- a/swift/Tests/AgentSquadTests/OpenAIGroundedVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIGroundedVoiceAssistantTests.swift
@@ -68,6 +68,55 @@ import Testing
         #expect(log.states.last == .listening)
     }
 
+    @Test func presenterBargeInSendsNoTruncate() async throws {
+        // The presenter is out-of-band (`conversation: "none"`) — its items never enter the
+        // conversation, so truncating one is a server error. Barge-in must skip the frame.
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let session = session(transport, tools: oddsTools())
+        await session.setPlaybackClock { 40 }
+        log.start(session)
+        try await session.start()
+
+        // Drive a real grounded turn so the presenter is active (tool → settle → present).
+        transport.push(funcArgs("r1", "c1", "odds"))
+        transport.push(responseDone("r1"))
+        transport.push(responseDone("r2"))
+        await eventually { transport.sent.contains { $0.contains("\"role\":\"presenter\"") } }
+        transport.push(responseCreated("p1", role: "presenter"))
+        transport.push(audioDelta("p1", String(repeating: "x", count: 4_800)))   // 100 ms received
+        await eventually { log.audioCount == 1 }
+
+        transport.push(#"{"type":"input_audio_buffer.speech_started"}"#)
+        await eventually { sentTypes(transport).contains("response.cancel") }
+        #expect(!sentTypes(transport).contains("conversation.item.truncate"))
+    }
+
+    @Test func directReplyBargeInTruncatesTheHeardPortion() async throws {
+        // The direct (no-tool) reply is in-band — barge-in truncates like the plain assistant.
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let session = session(transport, tools: oddsTools())
+        await session.setPlaybackClock { 40 }
+        log.start(session)
+        try await session.start()
+
+        // Agent settles with no tools but with text → speakDirectly() creates the direct reply.
+        transport.push(responseCreated("r1"))
+        transport.push(#"{"type":"response.output_text.delta","response_id":"r1","delta":"hi"}"#)
+        transport.push(responseDone("r1"))
+        await eventually { transport.sent.contains { $0.contains("\"role\":\"direct\"") } }
+        transport.push(responseCreated("d1", role: "direct"))
+        transport.push(audioDelta("d1", String(repeating: "x", count: 4_800), item: "item_3"))
+        await eventually { log.audioCount == 1 }
+
+        transport.push(#"{"type":"input_audio_buffer.speech_started"}"#)
+        await eventually { sentTypes(transport).contains("response.cancel") }
+        let frame = try #require(transport.sent.first { $0.contains("conversation.item.truncate") })
+        #expect(frame.contains(#""item_id":"item_3""#))
+        #expect(frame.contains(#""audio_end_ms":40"#))
+    }
+
     @Test func agentTextIsAccumulatedNotEmittedWhileNoPresenterIsActive() async throws {
         let transport = MockRealtimeTransport()
         let log = EventLog()

--- a/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
@@ -131,6 +131,68 @@ import Testing
         #expect(log.audioCount == 1)
     }
 
+    @Test func bargeInTruncatesTheHeardPortion() async throws {
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let session = session(transport)
+        await session.setPlaybackClock { 40 }   // 40 ms actually played
+        log.start(session)
+        try await session.start()
+
+        transport.push(responseCreated("r1"))
+        // 4 800 PCM16 bytes = 100 ms @ 24 kHz — more than the 40 ms played, so truncation applies.
+        transport.push(audioDelta("r1", String(repeating: "x", count: 4_800), item: "item_7"))
+        await eventually { log.audioCount == 1 }   // delta processed → truncation state recorded
+
+        transport.push(#"{"type":"input_audio_buffer.speech_started"}"#)
+        await eventually { sentTypes(transport).contains("response.cancel") }
+
+        let truncate = transport.sent.first { $0.contains("conversation.item.truncate") }
+        let frame = try #require(truncate)
+        #expect(frame.contains(#""item_id":"item_7""#))
+        #expect(frame.contains(#""audio_end_ms":40"#))
+        #expect(frame.contains(#""content_index":0"#))
+        // Ordering: truncate goes out before the cancel.
+        let types = sentTypes(transport)
+        let truncateIdx = try #require(types.firstIndex(of: "conversation.item.truncate"))
+        let cancelIdx = try #require(types.firstIndex(of: "response.cancel"))
+        #expect(truncateIdx < cancelIdx)
+    }
+
+    @Test func bargeInSkipsTruncateWhenEverythingWasPlayed() async throws {
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let session = session(transport)
+        await session.setPlaybackClock { 500 }   // clock ≥ received (100 ms) — stale or fully played
+        log.start(session)
+        try await session.start()
+
+        transport.push(responseCreated("r1"))
+        transport.push(audioDelta("r1", String(repeating: "x", count: 4_800)))
+        await eventually { log.audioCount == 1 }
+
+        transport.push(#"{"type":"input_audio_buffer.speech_started"}"#)
+        await eventually { sentTypes(transport).contains("response.cancel") }
+        // audio_end_ms greater than the actual duration is a server error (client-events spec) — never sent.
+        #expect(!sentTypes(transport).contains("conversation.item.truncate"))
+    }
+
+    @Test func bargeInWithoutAClockSendsNoTruncate() async throws {
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let session = session(transport)   // no setPlaybackClock
+        log.start(session)
+        try await session.start()
+
+        transport.push(responseCreated("r1"))
+        transport.push(audioDelta("r1", String(repeating: "x", count: 4_800)))
+        await eventually { log.audioCount == 1 }
+
+        transport.push(#"{"type":"input_audio_buffer.speech_started"}"#)
+        await eventually { sentTypes(transport).contains("response.cancel") }
+        #expect(!sentTypes(transport).contains("conversation.item.truncate"))
+    }
+
     @Test func noToolTurnSpeaksAndFinishes() async throws {
         let transport = MockRealtimeTransport()
         let log = EventLog()

--- a/swift/Tests/AgentSquadTests/RealtimeRuntimeTests.swift
+++ b/swift/Tests/AgentSquadTests/RealtimeRuntimeTests.swift
@@ -15,18 +15,23 @@ import Testing
         private var _sentText: [String] = []
         private var _interrupts = 0
         private var _stopped = false
+        private var _clock: (@Sendable () async -> Double?)?
 
         init() { (events, cont) = AsyncStream.makeStream(of: RealtimeEvent.self) }
         var sentAudio: [Data] { lock.withLock { _sentAudio } }
         var sentText: [String] { lock.withLock { _sentText } }
         var interrupts: Int { lock.withLock { _interrupts } }
         var stopped: Bool { lock.withLock { _stopped } }
+        var clock: (@Sendable () async -> Double?)? { lock.withLock { _clock } }
 
         func start() async throws {}
         func sendAudio(_ pcm16: Data) async { lock.withLock { _sentAudio.append(pcm16) } }
         func sendText(_ text: String) async { lock.withLock { _sentText.append(text) } }
         func interrupt() async { lock.withLock { _interrupts += 1 }; cont.yield(.audioDone(interrupted: true)) }
         func stop() async { lock.withLock { _stopped = true }; cont.finish() }
+        func setPlaybackClock(_ playedMilliseconds: @escaping @Sendable () async -> Double?) async {
+            lock.withLock { _clock = playedMilliseconds }
+        }
         func push(_ event: RealtimeEvent) { cont.yield(event) }
     }
 
@@ -47,13 +52,16 @@ import Testing
         private var _enqueued: [Data] = []
         private var _flushes = 0
         private var _stopped = false
+        private var _calls: [String] = []   // ordering assertions (flush vs played)
         var enqueued: [Data] { lock.withLock { _enqueued } }
         var flushes: Int { lock.withLock { _flushes } }
         var stopped: Bool { lock.withLock { _stopped } }
+        var calls: [String] { lock.withLock { _calls } }
         func start() async throws {}
         func enqueue(_ pcm16: Data) async { lock.withLock { _enqueued.append(pcm16) } }
-        func flush() async { lock.withLock { _flushes += 1 } }
+        func flush() async { lock.withLock { _flushes += 1; _calls.append("flush") } }
         func stop() async { lock.withLock { _stopped = true } }
+        func playedMilliseconds() async -> Double? { lock.withLock { _calls.append("played") }; return 42 }
     }
 
     private final class EventLog: @unchecked Sendable {
@@ -101,6 +109,18 @@ import Testing
     }
 
     // MARK: - Tests
+
+    @Test func installedPlaybackClockSamplesThenCutsPlayback() async throws {
+        // Sample BEFORE the flush: a flush re-arms the burst, so a stale pump enqueue racing in
+        // after it would zero the total. The cut still happens inside the closure — before the
+        // session sends the truncate frame (the docs' stop-before-truncate).
+        let (runtime, session, _, output) = make()
+        try await runtime.start()
+        let clock = try #require(session.clock)
+        let played = await clock()
+        #expect(played == 42)
+        #expect(output.calls == ["played", "flush"])
+    }
 
     @Test func forwardsMicFramesToSession() async throws {
         let (runtime, session, input, _) = make()

--- a/swift/Tests/AgentSquadTests/RealtimeTestSupport.swift
+++ b/swift/Tests/AgentSquadTests/RealtimeTestSupport.swift
@@ -195,8 +195,9 @@ func responseCreated(_ id: String, role: String? = nil) -> String {
     return #"{"type":"response.created","response":{"id":"\#(id)"}}"#   // the gatherer/agent turn — no role
 }
 
-func audioDelta(_ id: String, _ bytes: String) -> String {
-    #"{"type":"response.output_audio.delta","response_id":"\#(id)","delta":"\#(Data(bytes.utf8).base64EncodedString())"}"#
+func audioDelta(_ id: String, _ bytes: String, item: String = "item_1") -> String {
+    // `item_id` is required on the real event (see reference/server-events.md).
+    #"{"type":"response.output_audio.delta","response_id":"\#(id)","item_id":"\#(item)","delta":"\#(Data(bytes.utf8).base64EncodedString())"}"#
 }
 
 func userSaid(_ text: String) -> String {

--- a/swift/Tests/AgentSquadTests/RealtimeWireTests.swift
+++ b/swift/Tests/AgentSquadTests/RealtimeWireTests.swift
@@ -165,9 +165,35 @@ import Testing
 
     @Test func decodesGAAndLegacyAudioDeltaToTheSameEvent() {
         for type in ["response.output_audio.delta", "response.audio.delta"] {
-            let event = RealtimeWire.decode(#"{"type":"\#(type)","response_id":"p1","delta":"AAAA"}"#)
-            #expect(event == .audioDelta(responseId: "p1", base64: "AAAA"))
+            let event = RealtimeWire.decode(#"{"type":"\#(type)","response_id":"p1","item_id":"item_9","delta":"AAAA"}"#)
+            #expect(event == .audioDelta(responseId: "p1", itemId: "item_9", base64: "AAAA"))
         }
+    }
+
+    @Test func truncationStateIsPerItemAcrossABurst() {
+        // Tool→continue turns speak several items back-to-back without playback draining: the
+        // burst clock covers all of them, so the frame must subtract the previous items' audio.
+        var state = AudioTruncationState()
+        state.record(itemId: "item_A", pcm16ByteCount: 24_000, sampleRate: 24_000)   // 500 ms
+        state.record(itemId: "item_B", pcm16ByteCount: 144_000, sampleRate: 24_000)  // 3 000 ms
+        // Burst played 800 ms total = all of A (500) + 300 of B → truncate B at 300, not 800.
+        let frame = state.truncateFrame(playedMs: 800)
+        #expect(frame?.contains(#""item_id":"item_B""#) == true)
+        #expect(frame?.contains(#""audio_end_ms":300"#) == true)
+        // Clock restarted (burst drained between items) → played < offset → skip, never negative.
+        #expect(state.truncateFrame(playedMs: 200) == nil)
+        // Stale clock beyond this item's received audio → skip (server errors past the duration).
+        #expect(state.truncateFrame(playedMs: 4_000) == nil)
+        #expect(state.truncateFrame(playedMs: nil) == nil)
+    }
+
+    @Test func truncateItemFrameMatchesTheSpec() throws {
+        // reference/client-events.md: required fields type/item_id/content_index/audio_end_ms; content_index is 0.
+        let json = try object(RealtimeWire.truncateItem(itemId: "item_002", audioEndMs: 1_500))
+        #expect(json["type"] as? String == "conversation.item.truncate")
+        #expect(json["item_id"] as? String == "item_002")
+        #expect(json["content_index"] as? Int == 0)
+        #expect(json["audio_end_ms"] as? Int == 1_500)
     }
 
     @Test func audioTranscriptDeltaIsNotMistakenForAudioDelta() {


### PR DESCRIPTION
## Issue Link

Fixes #561

## Summary

The Swift realtime session (WebSocket transport) stopped playback and cancelled the response on barge-in but never sent `conversation.item.truncate`, so the server's conversation kept audio the user never heard — the model believed the user heard everything. This implements step 3 of the OpenAI Realtime WebSocket interruption procedure: on interrupt, the session now tells the server how much audio was actually played, and the server drops the unheard audio and its transcript from context.

## Changes

- `RealtimeWire.truncateItem(itemId:audioEndMs:)` + `item_id` decoded on audio deltas (required field per the OpenAPI spec)
- `AudioOutput.playedMilliseconds()` — new protocol member with a protocol-extension default returning `nil`, so existing custom conformances keep compiling (truncation is simply skipped without a clock)
- `PlaybackClock` (AgentSquadAudio) — played-ms accounting via `.dataPlayedBack` buffer callbacks in `AudioPlayback` and `VoiceProcessedAudioIO`; survives `flush()` so the session can sample it right after the barge-in cut; all edge cases (mid-response stall, voided pending buffers) err toward under-reporting, never claiming unheard audio was played
- `AudioTruncationState` — per-item accounting (a tool→continue turn speaks several items in one playback burst); the frame is skipped rather than ever exceeding the item's actual audio duration, which the spec defines as a server error
- Both assistants send truncate before `response.cancel`; `RealtimeRuntime` injects the clock via the new `VoiceAssistant.setPlaybackClock` (default no-op)
- Grounded sessions: only the in-band `direct` reply truncates — the presenter is out-of-band (`conversation: "none"`), its items never enter the conversation, so truncating one would error on every grounded barge-in

## User experience

Interrupt the assistant mid-answer, then ask "what was the last thing you said?" — the model now answers from what was actually heard instead of content that was never played. No API changes required in apps; custom `AudioOutput` implementations can opt in by implementing `playedMilliseconds()`.

## Checklist

- [x] All wire shapes verified against the official OpenAI Realtime API reference
- [x] 359 tests pass (12 new: wire spec, per-item accounting, clock semantics, 6 session contract tests)
- [x] iOS `xcodebuild` succeeds (matches CI)
- [x] swift/README.md, swift/SKILL.md, and docs-site audio pages updated
- [x] swift-tech-lead review: 2 REQUIRED findings fixed (presenter out-of-band gate, per-item burst offset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)