### PR TITLE
feat(swift): TransformingChatStorage — pre-save message transform (PII scrub)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -240,6 +240,7 @@ export default defineConfig({
 											{ label: 'In-memory', slug: 'swift/storage/built-in/in-memory' },
 											{ label: 'File', slug: 'swift/storage/built-in/file' },
 											{ label: 'Device (SwiftData)', slug: 'swift/storage/built-in/device' },
+											{ label: 'Transforming (PII scrub)', slug: 'swift/storage/built-in/transforming' },
 										],
 									},
 									{ label: 'Custom store', slug: 'swift/storage/custom' },

--- a/docs/src/content/docs/swift/storage/built-in/transforming.md
+++ b/docs/src/content/docs/swift/storage/built-in/transforming.md
@@ -1,0 +1,142 @@
+---
+title: TransformingChatStorage
+description: Wrap any ChatStorage with a message transform that runs before persistence — strip PII, redact tokens, clip payloads, or drop messages entirely.
+---
+
+`TransformingChatStorage` wraps any `ChatStorage` — built-in or custom — and runs a `MessageTransform` on every message **before it is saved**. It is the seam for PII scrubbing and message shaping at the persistence boundary: what reaches disk is the transformed form, so scrubbed data also never re-enters prompts when history is fetched later.
+
+```swift
+import AgentSquad
+
+public typealias MessageTransform = @Sendable (ConversationMessage) async throws -> ConversationMessage?
+
+let store = TransformingChatStorage(wrapping: FileChatStorage()) { message in
+    message.mappingText { text in
+        text.replacing(#/\b[A-Z]{2}\d{2}(?: ?\d{4}){4,7}\b/#, with: "[IBAN]")
+    }
+}
+let orchestrator = Orchestrator(agents: [agent], store: store)
+```
+
+Reads (`fetch`, `fetchAllChats`) pass through to the wrapped store untouched.
+
+---
+
+## The transform
+
+| Return | Effect |
+|---|---|
+| a modified message | the modified form is persisted (same `id`/`role`/`timestamp` — see `mappingText`) |
+| the message unchanged | persisted as-is |
+| `nil` | the message is **dropped** — nothing persisted |
+| `throw` | the save **fails loudly** — nothing is persisted unscrubbed |
+
+The closure is `async`, so an on-device model (e.g. `NLTagger`-based entity detection) can do the scrubbing.
+
+### `mappingText` — the common case
+
+Most transforms only touch text. `ConversationMessage.mappingText(_:)` runs a closure over every string part — `.text` **and** `.audioTranscript` — and leaves structured parts (`toolCall`/`toolResult` payloads, widgets) alone, preserving `id`, `role`, and `timestamp`:
+
+```swift
+message.mappingText { $0.replacingOccurrences(of: cardNumber, with: "[CARD]") }
+```
+
+---
+
+## Worked transforms
+
+Reusable functions typed as `MessageTransform` — define once, pass to any wrapper.
+
+**Pattern-based PII scrub** (IBANs, card-length digit runs, emails):
+
+```swift
+let scrubPII: MessageTransform = { message in
+    message.mappingText { text in
+        var scrubbed = text
+        scrubbed = scrubbed.replacing(#/\b[A-Z]{2}\d{2}(?: ?\d{4}){4,7}\b/#, with: "[IBAN]")
+        scrubbed = scrubbed.replacing(#/\b(?:\d[ -]?){13,19}\b/#, with: "[CARD]")
+        scrubbed = scrubbed.replacing(#/[\w.+-]+@[\w-]+\.[\w.]+/#, with: "[EMAIL]")
+        return scrubbed
+    }
+}
+
+let store = TransformingChatStorage(wrapping: FileChatStorage(), transform: scrubPII)
+```
+
+**Name detection with an on-device model** (`NLTagger`) — collect ranges first, replace in reverse so earlier ranges stay valid:
+
+```swift
+import NaturalLanguage
+
+let scrubNames: MessageTransform = { message in
+    message.mappingText { text in
+        let tagger = NLTagger(tagSchemes: [.nameType])
+        tagger.string = text
+        var ranges: [Range<String.Index>] = []
+        tagger.enumerateTags(in: text.startIndex..<text.endIndex, unit: .word, scheme: .nameType,
+                             options: [.omitWhitespace, .omitPunctuation]) { tag, range in
+            if tag == .personalName { ranges.append(range) }
+            return true
+        }
+        var scrubbed = text
+        for range in ranges.reversed() { scrubbed.replaceSubrange(range, with: "[NAME]") }
+        return scrubbed
+    }
+}
+```
+
+**Dropping messages** — keep operator/debug turns out of history entirely (mind the pairing caution below):
+
+```swift
+let dropDebugTurns: MessageTransform = { message in
+    message.text.hasPrefix("/debug") ? nil : message
+}
+```
+
+**Failing closed** — when the scrubber itself can error, throw rather than persist raw data:
+
+```swift
+struct ScrubberUnavailable: Error {}
+
+let strictScrub: MessageTransform = { message in
+    // Scrubber = your on-device scrubbing service; stands in for whatever does the real work.
+    guard await Scrubber.shared.isReady else { throw ScrubberUnavailable() }
+    return await Scrubber.shared.scrub(message)
+}
+```
+
+:::caution
+Prefer **redacting** over dropping. Stores skip a save whose role repeats the last stored message's (the consecutive-same-role guard) — so dropping one side of an exchange can make the store silently skip its counterpart too, e.g. drop the assistant reply and the *next user message* is refused as user-after-user.
+:::
+
+---
+
+## Composing
+
+It's a plain `ChatStorage`, so it drops in anywhere one goes and wraps anything, including another wrapper:
+
+```swift
+let clipLongMessages: MessageTransform = { message in
+    message.mappingText { String($0.prefix(4_000)) }
+}
+
+// Scrub FIRST, then clip, over the SwiftData store (the outer transform runs first).
+// Scrub-before-clip matters: clipping mid-match (e.g. half a card number) would leave a
+// fragment the scrub patterns no longer recognize.
+let store = TransformingChatStorage(
+    wrapping: TransformingChatStorage(wrapping: try DeviceChatStorage(userId: "u1"), transform: clipLongMessages),
+    transform: scrubPII
+)
+```
+
+:::note
+This transforms what reaches **storage**. For scrubbing what reaches **trace backends**, supply a custom `Redactor` to the tracing pipeline instead — the two seams are independent.
+:::
+
+---
+
+## Related pages
+
+- [Storage overview](/agent-squad/swift/storage/overview/) — the `ChatStorage` protocol
+- [File](/agent-squad/swift/storage/built-in/file/) · [Device (SwiftData)](/agent-squad/swift/storage/built-in/device/) · [In-memory](/agent-squad/swift/storage/built-in/in-memory/) — stores to wrap
+- [Custom store](/agent-squad/swift/storage/custom/) — implementing `ChatStorage` yourself

--- a/docs/src/content/docs/swift/storage/overview.md
+++ b/docs/src/content/docs/swift/storage/overview.md
@@ -77,6 +77,8 @@ Passing `store: nil` to the Orchestrator or voice assistant disables persistence
 
 For [voice](/agent-squad/swift/voice/overview/) sessions the same stores apply — pass the chosen instance to the voice assistant's `store:` parameter exactly as you would for a text Orchestrator.
 
+Any of them can be wrapped in [`TransformingChatStorage`](/agent-squad/swift/storage/built-in/transforming/) to scrub PII or reshape messages before they are persisted.
+
 :::note
 `InMemoryChatStorage` is scope-agnostic and returns no `[agentId]` prefix from `fetchAllChats`. For multi-agent Orchestrators where the Classifier needs routing attribution, use one of the persistent stores.
 :::
@@ -88,6 +90,7 @@ For [voice](/agent-squad/swift/voice/overview/) sessions the same stores apply �
 - [InMemoryChatStorage](/agent-squad/swift/storage/built-in/in-memory/) — non-persistent, seedable, iOS 16+
 - [FileChatStorage](/agent-squad/swift/storage/built-in/file/) — JSON files, iOS 16+
 - [DeviceChatStorage](/agent-squad/swift/storage/built-in/device/) — SwiftData, iOS 17+ / macOS 14+
+- [TransformingChatStorage](/agent-squad/swift/storage/built-in/transforming/) — wraps any store; PII scrub / message transform before saving, iOS 16+
 
 ## Custom store
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -212,7 +212,7 @@ the integrations you need (each isolates its own dependencies):
 
 | Library | `import` | Pulls in | Contents |
 |---|---|---|---|
-| **`AgentSquad`** (core) | `import AgentSquad` | **nothing external** | protocols, agents, orchestrator, native tools (`ToolKit`, `Tool.local`/`.http`, `HTTPToolGroup`, `AggregateToolProvider`), `FileChatStorage`, `DeviceChatStorage` _(iOS 17+)_, `InMemoryChatStorage`, `OSLogTracer` |
+| **`AgentSquad`** (core) | `import AgentSquad` | **nothing external** | protocols, agents, orchestrator, native tools (`ToolKit`, `Tool.local`/`.http`, `HTTPToolGroup`, `AggregateToolProvider`), `FileChatStorage`, `DeviceChatStorage` _(iOS 17+)_, `InMemoryChatStorage`, `TransformingChatStorage`, `OSLogTracer` |
 | **`AgentSquadMCP`** | `import AgentSquadMCP` | the official [MCP Swift SDK](https://github.com/modelcontextprotocol/swift-sdk) | `MCPServer` (alias of `MCPToolProvider`) — connect any MCP server with `MCPServer(url:)`, with MCP Apps UI support |
 | **`AgentSquadAudio`** | `import AgentSquadAudio` | AVFoundation (Apple platforms only) | `VoiceProcessedAudioIO` (echo-cancelled capture + playback on one engine — the recommended wiring), `MicCapture`, `AudioPlayback` for the realtime voice runtime — requires `NSMicrophoneUsageDescription` in your Info.plist |
 

--- a/swift/SKILL.md
+++ b/swift/SKILL.md
@@ -31,7 +31,7 @@ Every component is a `Sendable` protocol with one built-in implementation — sw
 
 | Import | Pulls in | Contents |
 |---|---|---|
-| `AgentSquad` | nothing external | protocols, `Agent`, `GroundedAgent`, `Orchestrator`, `LLMClassifier`, `ChatCompletionsClient`, `FileChatStorage`, `DeviceChatStorage`, `InMemoryChatStorage`, `OSLogTracer`, OTLP export |
+| `AgentSquad` | nothing external | protocols, `Agent`, `GroundedAgent`, `Orchestrator`, `LLMClassifier`, `ChatCompletionsClient`, `FileChatStorage`, `DeviceChatStorage`, `InMemoryChatStorage`, `TransformingChatStorage`, `OSLogTracer`, OTLP export |
 | `AgentSquadMCP` | MCP Swift SDK | `MCPServer` (= `MCPToolProvider`), `SDKMCPClient` |
 | `AgentSquadAudio` | AVFoundation | `VoiceProcessedAudioIO` (capture+playback, one engine, AEC — the recommended wiring), `MicCapture` (voice-processed/AEC by default), `AudioPlayback`, `VoiceProcessing`, `AudioSessionPolicy` (needs `NSMicrophoneUsageDescription`) |
 
@@ -71,7 +71,7 @@ stream. `.final` is what the orchestrator persists. Inputs/messages are value ty
   config once, then one line per endpoint; **`MCPServer(url:)`** connects an MCP server; and
   **`AggregateToolProvider`** composes any mix behind one seam. A `ToolResult` is three-part: text →
   the model's context, `structuredContent` → curator/UI data, `ui` → an optional widget.
-- **`FileChatStorage`** (JSON files, iOS 16+) and **`DeviceChatStorage`** (SwiftData, iOS 17+) persist history on-device; **`InMemoryChatStorage`** is a non-persistent, seedable single-conversation store. **`OSLogTracer`** is the default
+- **`FileChatStorage`** (JSON files, iOS 16+) and **`DeviceChatStorage`** (SwiftData, iOS 17+) persist history on-device; **`InMemoryChatStorage`** is a non-persistent, seedable single-conversation store. **`TransformingChatStorage`** wraps any store and runs a `MessageTransform` before each save (PII scrub / redact / drop) — reads pass through, `message.mappingText { … }` covers the text-only case. **`OSLogTracer`** is the default
   tracer; wire `ProcessingTracer` + `OTLPExporter` to ship traces to Langfuse/LangSmith/Datadog/…
 - **Voice**: two `VoiceAssistant`s over a WebSocket — `OpenAIVoiceAssistant` (single LLM, speaks
   directly) and `OpenAIGroundedVoiceAssistant` (grounded Brain → Presenter). Both are self-sufficient
@@ -118,7 +118,7 @@ signatures live in `Sources/AgentSquad/`.
 - **`ChatCompletionsClient`**: retries only *before the first event*; some local runtimes reject
   `stream_options`/unknown body keys — override via `extraBody`.
 - **`JSONValue`**: whole-number doubles decode to `.int`; carry large IDs as `.string`.
-- **Storage**: `FileChatStorage` (JSON, iOS 16+, scopes per-call by `userId`/`sessionId`/`agentId` — e.g. `sessionId` to isolate per match) or `DeviceChatStorage` (SwiftData, iOS 17+, bound to one `userId`). Both default to Library/Caches (disposable). `InMemoryChatStorage` (iOS 16+) is non-persistent and holds one conversation — construct it empty or seeded with a prior conversation to load one into a session.
+- **Storage**: `FileChatStorage` (JSON, iOS 16+, scopes per-call by `userId`/`sessionId`/`agentId` — e.g. `sessionId` to isolate per match) or `DeviceChatStorage` (SwiftData, iOS 17+, bound to one `userId`). Both default to Library/Caches (disposable). `InMemoryChatStorage` (iOS 16+) is non-persistent and holds one conversation — construct it empty or seeded with a prior conversation to load one into a session. Wrap any store in `TransformingChatStorage` to scrub/redact before persistence; prefer redacting over returning `nil` (dropping one side of an exchange can make the store skip its counterpart via the consecutive-same-role guard).
 - **Tracing lifecycle**: nothing drains the tracer for you — flush on background, shut down on
   termination. `OSLogTracer` logs no payloads. `Redaction` hashes ids + clips strings but does **not**
   pattern-scrub PII — supply a custom `Redactor` for that.

--- a/swift/Sources/AgentSquad/Storage/TransformingChatStorage.swift
+++ b/swift/Sources/AgentSquad/Storage/TransformingChatStorage.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// A message transform run before persistence: strip PII, redact tokens, clip oversized payloads —
+/// or return `nil` to drop the message entirely (not persisted). Throwing fails the save loudly —
+/// the alternative to silently persisting unscrubbed data when a scrubber errors.
+public typealias MessageTransform = @Sendable (ConversationMessage) async throws -> ConversationMessage?
+
+/// Wraps any `ChatStorage` and runs a `MessageTransform` on every message before it reaches the
+/// wrapped store — the seam for PII scrubbing and message shaping at the persistence boundary.
+/// Reads pass through untouched: history returns what was persisted, i.e. the transformed form
+/// (which is the point — scrubbed data never re-enters prompts from storage).
+///
+/// ```swift
+/// let store = TransformingChatStorage(wrapping: FileChatStorage()) { message in
+///     message.mappingText { $0.replacing(iban, with: "[IBAN]") }
+/// }
+/// ```
+///
+/// Dropping a message (`nil`) can leave an unpaired exchange: stores skip a save whose role
+/// repeats the last stored message's, so the counterpart of a dropped message may be skipped too.
+public struct TransformingChatStorage: ChatStorage {
+    private let base: any ChatStorage
+    private let transform: MessageTransform
+
+    public init(wrapping base: any ChatStorage, transform: @escaping MessageTransform) {
+        self.base = base
+        self.transform = transform
+    }
+
+    public func fetch(
+        userId: String, sessionId: String, agentId: String, maxMessages: Int?
+    ) async throws -> [ConversationMessage] {
+        try await base.fetch(userId: userId, sessionId: sessionId, agentId: agentId, maxMessages: maxMessages)
+    }
+
+    public func save(
+        _ message: ConversationMessage,
+        userId: String, sessionId: String, agentId: String, maxMessages: Int?
+    ) async throws {
+        guard let transformed = try await transform(message) else { return }
+        try await base.save(transformed, userId: userId, sessionId: sessionId, agentId: agentId, maxMessages: maxMessages)
+    }
+
+    public func saveMessages(
+        _ messages: [ConversationMessage],
+        userId: String, sessionId: String, agentId: String, maxMessages: Int?
+    ) async throws {
+        var transformed: [ConversationMessage] = []
+        for message in messages {
+            if let message = try await transform(message) { transformed.append(message) }
+        }
+        guard !transformed.isEmpty else { return }
+        try await base.saveMessages(transformed, userId: userId, sessionId: sessionId, agentId: agentId, maxMessages: maxMessages)
+    }
+
+    public func fetchAllChats(userId: String, sessionId: String) async throws -> [ConversationMessage] {
+        try await base.fetchAllChats(userId: userId, sessionId: sessionId)
+    }
+}
+
+public extension ConversationMessage {
+    /// The same message with every string part — `.text` AND `.audioTranscript` — run through
+    /// `transform`: the common PII-scrub shape. Structured parts (`toolCall`/`toolResult` payloads,
+    /// widgets) pass through; use a full `MessageTransform` to touch those.
+    func mappingText(_ transform: (String) throws -> String) rethrows -> ConversationMessage {
+        let parts = try parts.map { part in
+            switch part {
+            case .text(let text): ContentPart.text(try transform(text))
+            case .audioTranscript(let text): ContentPart.audioTranscript(try transform(text))
+            default: part
+            }
+        }
+        return ConversationMessage(id: id, role: role, parts: parts, timestamp: timestamp)
+    }
+}

--- a/swift/Tests/AgentSquadTests/TransformingChatStorageTests.swift
+++ b/swift/Tests/AgentSquadTests/TransformingChatStorageTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+
+@testable import AgentSquad
+
+@Suite struct TransformingChatStorageTests {
+    private func user(_ t: String) -> ConversationMessage { ConversationMessage(role: .user, text: t) }
+    private func assistant(_ t: String) -> ConversationMessage { ConversationMessage(role: .assistant, text: t) }
+    private func texts(_ messages: [ConversationMessage]) -> [String] {
+        messages.map { $0.parts.compactMap { if case .text(let t) = $0 { return t } else { return nil } }.joined() }
+    }
+
+    @Test func transformsMessagesBeforeSaving() async throws {
+        let store = TransformingChatStorage(wrapping: InMemoryChatStorage()) { message in
+            message.mappingText { $0.replacingOccurrences(of: "4242 4242 4242 4242", with: "[CARD]") }
+        }
+        try await store.save(user("my card is 4242 4242 4242 4242"), userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+        try await store.saveMessages([assistant("noted 4242 4242 4242 4242")], userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+
+        let history = try await store.fetch(userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+        #expect(texts(history) == ["my card is [CARD]", "noted [CARD]"])   // scrubbed form persisted, reads pass through
+    }
+
+    @Test func nilDropsTheMessage() async throws {
+        let store = TransformingChatStorage(wrapping: InMemoryChatStorage()) { message in
+            message.text.contains("secret") ? nil : message
+        }
+        try await store.save(user("hello"), userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+        try await store.save(assistant("the secret is 42"), userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+
+        let history = try await store.fetch(userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+        #expect(texts(history) == ["hello"])
+    }
+
+    @Test func droppingAMessageCanSkipItsCounterpartToo() async throws {
+        // The documented pairing side-effect: dropping the assistant reply makes the next user
+        // message consecutive-same-role in the base store, which then skips it.
+        let store = TransformingChatStorage(wrapping: InMemoryChatStorage()) { message in
+            message.text.contains("secret") ? nil : message
+        }
+        try await store.save(user("hello"), userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+        try await store.saveMessages([assistant("the secret is 42"), user("bye")], userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+
+        let history = try await store.fetch(userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+        #expect(texts(history) == ["hello"])   // "bye" skipped — prefer redacting over dropping
+    }
+
+    /// Records `saveMessages` calls — proves the wrapper never bothers the base with an empty batch
+    /// (a spurious write in `FileChatStorage`, unknown side effects in custom stores).
+    private actor SpyStorage: ChatStorage {
+        private(set) var saveBatches: [[ConversationMessage]] = []
+        func fetch(userId: String, sessionId: String, agentId: String, maxMessages: Int?) async throws -> [ConversationMessage] { [] }
+        func save(_ message: ConversationMessage, userId: String, sessionId: String, agentId: String, maxMessages: Int?) async throws {}
+        func saveMessages(_ messages: [ConversationMessage], userId: String, sessionId: String, agentId: String, maxMessages: Int?) async throws {
+            saveBatches.append(messages)
+        }
+        func fetchAllChats(userId: String, sessionId: String) async throws -> [ConversationMessage] { [] }
+    }
+
+    @Test func allDroppedSkipsTheBaseSaveEntirely() async throws {
+        let spy = SpyStorage()
+        let store = TransformingChatStorage(wrapping: spy) { _ in nil }
+        try await store.saveMessages([user("a"), assistant("b")], userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+        #expect(await spy.saveBatches.isEmpty)   // nothing survived → the base is never called
+    }
+
+    @Test func aThrowingTransformFailsTheSave() async throws {
+        struct ScrubFailed: Error {}
+        let spy = SpyStorage()
+        let store = TransformingChatStorage(wrapping: spy) { _ in throw ScrubFailed() }
+        await #expect(throws: ScrubFailed.self) {
+            try await store.save(user("pii"), userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+        }
+        #expect(await spy.saveBatches.isEmpty)   // fails loudly, never persists unscrubbed
+    }
+
+    @Test func mappingTextAlsoCoversAudioTranscripts() async throws {
+        let message = ConversationMessage(role: .user, parts: [.audioTranscript("my card is 4242")])
+        let mapped = message.mappingText { $0.replacingOccurrences(of: "4242", with: "[CARD]") }
+        #expect(mapped.parts == [.audioTranscript("my card is [CARD]")])
+    }
+
+    @Test func transformKeepsMessageIdentityAndRole() async throws {
+        let original = user("call me on 0612345678")
+        let scrubbed = original.mappingText { $0.replacingOccurrences(of: "0612345678", with: "[PHONE]") }
+        #expect(scrubbed.id == original.id)
+        #expect(scrubbed.role == original.role)
+        #expect(scrubbed.timestamp == original.timestamp)
+        #expect(scrubbed.text == "call me on [PHONE]")
+    }
+
+    @Test func mappingTextLeavesNonTextPartsAlone() async throws {
+        let widget = ContentPart.widget(UIPayload(resourceURI: "ui://odds", mimeType: "text/html"))
+        let message = ConversationMessage(role: .assistant, parts: [.text("secret"), widget])
+        let mapped = message.mappingText { _ in "[REDACTED]" }
+        #expect(mapped.parts.count == 2)
+        #expect(mapped.text == "[REDACTED]")
+        #expect(mapped.parts[1] == widget)
+    }
+
+    @Test func docExampleScrubPIICompilesAndWorks() async throws {
+        // The `scrubPII` worked example from docs/swift/storage/built-in/transforming.md, verbatim.
+        let scrubPII: MessageTransform = { message in
+            message.mappingText { text in
+                var scrubbed = text
+                scrubbed = scrubbed.replacing(#/\b[A-Z]{2}\d{2}(?: ?\d{4}){4,7}\b/#, with: "[IBAN]")
+                scrubbed = scrubbed.replacing(#/\b(?:\d[ -]?){13,19}\b/#, with: "[CARD]")
+                scrubbed = scrubbed.replacing(#/[\w.+-]+@[\w-]+\.[\w.]+/#, with: "[EMAIL]")
+                return scrubbed
+            }
+        }
+        let store = TransformingChatStorage(wrapping: InMemoryChatStorage(), transform: scrubPII)
+        try await store.save(
+            user("pay XX12 3456 7890 1234 5678 or 4242 4242 4242 4242, mail c.croitoru@example.com"),
+            userId: "u", sessionId: "s", agentId: "a", maxMessages: nil
+        )
+        let history = try await store.fetch(userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)
+        #expect(texts(history) == ["pay [IBAN] or [CARD], mail [EMAIL]"])
+    }
+
+    @Test func readsPassThroughUnchanged() async throws {
+        let store = TransformingChatStorage(wrapping: InMemoryChatStorage([user("q"), assistant("a")])) { _ in nil }
+        // A drop-everything transform must not affect what fetch/fetchAllChats return.
+        #expect(texts(try await store.fetch(userId: "u", sessionId: "s", agentId: "a", maxMessages: nil)) == ["q", "a"])
+        #expect(texts(try await store.fetchAllChats(userId: "u", sessionId: "s")) == ["q", "a"])
+    }
+}


### PR DESCRIPTION
## Issue Link

Fixes #563

## Summary

Chat history persisted user messages and voice transcripts verbatim, with no seam to strip PII or reshape messages before they hit disk. This adds `TransformingChatStorage`: a decorator over any `ChatStorage` that runs a user-supplied `MessageTransform` on every message before persistence. Reads pass through, so the scrubbed form is also what re-enters prompts from history.

## Changes

- `TransformingChatStorage` (new, `swift/Sources/AgentSquad/Storage/`) — wraps any store, built-in or custom; wrappers compose (e.g. scrub then clip). An all-dropped batch never reaches the base store.
- `MessageTransform = @Sendable (ConversationMessage) async throws -> ConversationMessage?` — async so on-device models (NLTagger etc.) can scrub; `nil` drops the message; `throw` fails the save loudly instead of silently persisting unscrubbed data.
- `ConversationMessage.mappingText(_:)` — runs a closure over every string part (`.text` **and** `.audioTranscript`; voice transcripts are PII too), preserves `id`/`role`/`timestamp` and structured parts.
- Docs: new docs-site page with four complete worked transforms (regex PII scrub, NLTagger name detection, drop, fail-closed), sidebar entry, storage overview, README + SKILL.md. The main doc example is copied verbatim into a test so it's proven, not aspirational.

## User experience

```swift
let store = TransformingChatStorage(wrapping: FileChatStorage()) { message in
    message.mappingText { $0.replacing(iban, with: "[IBAN]") }
}
let orchestrator = Orchestrator(agents: [agent], store: store)
```

No changes for existing consumers; every store keeps its API.

Documented footguns: prefer redacting over dropping (dropping one side of an exchange can make the store skip its counterpart via the consecutive-same-role guard), and in composed wrappers scrub before clipping (clipping mid-match leaves PII fragments the patterns no longer recognize).

## Checklist

- [x] 357 tests pass (10 new, incl. a spy-store proof that empty batches never reach the base, and the verbatim doc-example test)
- [x] iOS `xcodebuild` succeeds (matches CI)
- [x] swift/README.md and swift/SKILL.md updated
- [x] swift-tech-lead review: APPROVED (doc examples compile-verified against the package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)