### PR TITLE
feat(typescript): add MCPToolProvider for MCP server integration

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-squad",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-squad",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.51.0",
@@ -39,6 +39,14 @@
         "ts-jest": "^29.2.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.3"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -46,6 +46,14 @@
     "prettier": "^3.3.3",
     "stopword": "^3.0.1"
   },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@types/jest": "^29.5.12",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -46,6 +46,7 @@ export { AgentOverlapAnalyzer, AnalysisResult } from "./agentOverlapAnalyzer";
 export { ConversationMessage, ParticipantRole } from "./types"
 export { AgentTools, AgentTool} from "./utils/tool"
 export { isClassifierToolInput } from './utils/helpers'
+export { MCPToolProvider, MCPServerConfig } from './tools/mcpToolProvider'
 
 
 import { MAOTS_VERSION } from "./common/src/version";

--- a/typescript/src/tools/mcpToolProvider.ts
+++ b/typescript/src/tools/mcpToolProvider.ts
@@ -23,20 +23,25 @@ export interface MCPServerConfig {
  * MCPToolProvider integrates one or more MCP (Model Context Protocol) servers
  * into the agent-squad tool system as a drop-in replacement for {@link AgentTools}.
  *
- * Pass it directly to `toolConfig.tool` — no other changes needed:
+ * Use the async factory {@link MCPToolProvider.create} to build a provider.
+ * It connects to all MCP servers before returning so that tool definitions are
+ * available synchronously when the agent builds its API request:
  *
  * @example
  * ```typescript
+ * const provider = await MCPToolProvider.create([
+ *   { type: "stdio", command: "uvx", args: ["my-mcp-server"] },
+ *   { type: "sse", url: "http://localhost:3000/sse" },
+ * ]);
+ *
  * const agent = new BedrockLLMAgent({
  *   name: "my-agent",
  *   description: "An agent with MCP tools",
- *   toolConfig: {
- *     tool: new MCPToolProvider([
- *       { type: "stdio", command: "uvx", args: ["my-mcp-server"] },
- *       { type: "sse", url: "http://localhost:3000/sse" },
- *     ]),
- *   },
+ *   toolConfig: { tool: provider },
  * });
+ *
+ * // When done, clean up server connections:
+ * await provider.disconnect();
  * ```
  *
  * The `@modelcontextprotocol/sdk` package must be installed separately:
@@ -56,6 +61,26 @@ export class MCPToolProvider extends AgentTools {
     // Start with an empty tools array; populated lazily on first use
     super([], callbacks);
     this.servers = servers;
+  }
+
+  /**
+   * Create a connected {@link MCPToolProvider}.
+   *
+   * Connects to all configured MCP servers and populates the internal tool list
+   * before returning. Use this instead of `new MCPToolProvider(...)` so that
+   * tool definitions are available when the agent builds its API request.
+   *
+   * @param servers - List of {@link MCPServerConfig} instances.
+   * @param callbacks - Optional lifecycle hooks.
+   * @returns A fully connected {@link MCPToolProvider}.
+   */
+  static async create(
+    servers: MCPServerConfig[],
+    callbacks?: AgentToolCallbacks
+  ): Promise<MCPToolProvider> {
+    const provider = new MCPToolProvider(servers, callbacks);
+    await provider.ensureConnected();
+    return provider;
   }
 
   // ---------------------------------------------------------------------------

--- a/typescript/src/tools/mcpToolProvider.ts
+++ b/typescript/src/tools/mcpToolProvider.ts
@@ -1,0 +1,351 @@
+import { AgentTool, AgentToolCallbacks, AgentToolResult, AgentTools } from "../utils/tool";
+import { ConversationMessage } from "../types";
+
+/**
+ * Configuration for a single MCP server connection.
+ */
+export interface MCPServerConfig {
+  /** Transport type: stdio (spawn a local process) or sse (HTTP SSE endpoint) */
+  type: "stdio" | "sse";
+  /** stdio only: command to execute */
+  command?: string;
+  /** stdio only: arguments for the command */
+  args?: string[];
+  /** stdio only: environment variables for the child process */
+  env?: Record<string, string>;
+  /** sse only: full URL of the SSE endpoint */
+  url?: string;
+  /** sse only: extra HTTP headers */
+  headers?: Record<string, string>;
+}
+
+/**
+ * MCPToolProvider integrates one or more MCP (Model Context Protocol) servers
+ * into the agent-squad tool system as a drop-in replacement for {@link AgentTools}.
+ *
+ * Pass it directly to `toolConfig.tool` — no other changes needed:
+ *
+ * @example
+ * ```typescript
+ * const agent = new BedrockLLMAgent({
+ *   name: "my-agent",
+ *   description: "An agent with MCP tools",
+ *   toolConfig: {
+ *     tool: new MCPToolProvider([
+ *       { type: "stdio", command: "uvx", args: ["my-mcp-server"] },
+ *       { type: "sse", url: "http://localhost:3000/sse" },
+ *     ]),
+ *   },
+ * });
+ * ```
+ *
+ * The `@modelcontextprotocol/sdk` package must be installed separately:
+ * ```
+ * npm install @modelcontextprotocol/sdk
+ * ```
+ */
+export class MCPToolProvider extends AgentTools {
+  private servers: MCPServerConfig[];
+  /** Connected MCP client instances, one per server */
+  private clients: any[] = [];
+  /** Map from MCP tool name → the client that owns it */
+  private toolClientMap: Map<string, any> = new Map();
+  private connected = false;
+
+  constructor(servers: MCPServerConfig[], callbacks?: AgentToolCallbacks) {
+    // Start with an empty tools array; populated lazily on first use
+    super([], callbacks);
+    this.servers = servers;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lazy connection
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Ensure all MCP servers are connected and the tool list is populated.
+   * Safe to call multiple times — only runs once.
+   */
+  async ensureConnected(): Promise<void> {
+    if (this.connected) return;
+
+    let ClientClass: any;
+    let StdioClientTransport: any;
+    let SSEClientTransport: any;
+
+    try {
+      // @ts-ignore — optional peerDependency; not available in type-checking until installed
+      const clientMod = await import("@modelcontextprotocol/sdk/client/index.js");
+      ClientClass = clientMod.Client;
+    } catch {
+      throw new Error(
+        "Install @modelcontextprotocol/sdk to use MCPToolProvider: npm install @modelcontextprotocol/sdk"
+      );
+    }
+
+    try {
+      // @ts-ignore — optional peerDependency
+      const stdioMod = await import("@modelcontextprotocol/sdk/client/stdio.js");
+      StdioClientTransport = stdioMod.StdioClientTransport;
+    } catch {
+      StdioClientTransport = null;
+    }
+
+    try {
+      // @ts-ignore — optional peerDependency
+      const sseMod = await import("@modelcontextprotocol/sdk/client/sse.js");
+      SSEClientTransport = sseMod.SSEClientTransport;
+    } catch {
+      SSEClientTransport = null;
+    }
+
+    const allTools: AgentTool[] = [];
+
+    for (const serverConfig of this.servers) {
+      let transport: any;
+
+      if (serverConfig.type === "stdio") {
+        if (!StdioClientTransport) {
+          throw new Error(
+            "StdioClientTransport not available — check your @modelcontextprotocol/sdk installation"
+          );
+        }
+        if (!serverConfig.command) {
+          throw new Error(
+            "MCPServerConfig with type 'stdio' requires a 'command' field"
+          );
+        }
+        transport = new StdioClientTransport({
+          command: serverConfig.command,
+          args: serverConfig.args ?? [],
+          env: serverConfig.env,
+        });
+      } else if (serverConfig.type === "sse") {
+        if (!SSEClientTransport) {
+          throw new Error(
+            "SSEClientTransport not available — check your @modelcontextprotocol/sdk installation"
+          );
+        }
+        if (!serverConfig.url) {
+          throw new Error(
+            "MCPServerConfig with type 'sse' requires a 'url' field"
+          );
+        }
+        transport = new SSEClientTransport(new URL(serverConfig.url), {
+          headers: serverConfig.headers ?? {},
+        });
+      } else {
+        throw new Error(
+          `Unsupported MCPServerConfig type: ${(serverConfig as any).type}`
+        );
+      }
+
+      const client = new ClientClass(
+        { name: "agent-squad-mcp-client", version: "1.0.0" },
+        { capabilities: {} }
+      );
+
+      await client.connect(transport);
+      this.clients.push(client);
+
+      const { tools: mcpTools } = await client.listTools();
+
+      for (const mcpTool of mcpTools) {
+        this.toolClientMap.set(mcpTool.name, client);
+
+        const schema = mcpTool.inputSchema ?? { type: "object", properties: {} };
+        const properties: Record<string, any> = schema.properties ?? {};
+        const required: string[] = schema.required ?? [];
+
+        // Build an AgentTool with a dummy func — actual execution goes through
+        // MCP via our overridden toolHandler.
+        const agentTool = new AgentTool({
+          name: mcpTool.name,
+          description: mcpTool.description ?? `MCP tool: ${mcpTool.name}`,
+          properties,
+          required,
+          func: async () => {
+            // Placeholder — never called; MCPToolProvider.toolHandler handles
+            // execution directly via the MCP client.
+            return null;
+          },
+        });
+
+        // Store the raw MCP input schema so format methods can pass it through
+        // unchanged (it is already valid JSON Schema).
+        (agentTool as any)._mcpInputSchema = schema;
+
+        allTools.push(agentTool);
+      }
+    }
+
+    this.tools = allTools;
+    this.connected = true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Format overrides — pass MCP inputSchema through directly
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns tool definitions in Amazon Bedrock Converse format.
+   * Triggers lazy MCP connection on first call.
+   */
+  async toBedrockFormat(): Promise<any[]> {
+    await this.ensureConnected();
+    return this.tools.map((tool) => ({
+      toolSpec: {
+        name: tool.name,
+        description: tool.description,
+        inputSchema: {
+          json: (tool as any)._mcpInputSchema ?? {
+            type: "object",
+            properties: tool.properties,
+            required: tool.required,
+          },
+        },
+      },
+    }));
+  }
+
+  /**
+   * Returns tool definitions in Anthropic Claude format.
+   * Triggers lazy MCP connection on first call.
+   */
+  async toAnthropicFormat(): Promise<any[]> {
+    await this.ensureConnected();
+    return this.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      input_schema: (tool as any)._mcpInputSchema ?? {
+        type: "object",
+        properties: tool.properties,
+        required: tool.required,
+      },
+    }));
+  }
+
+  /**
+   * Returns tool definitions in OpenAI Chat Completions format.
+   * Triggers lazy MCP connection on first call.
+   */
+  async toOpenAIFormat(): Promise<any[]> {
+    await this.ensureConnected();
+    return this.tools.map((tool) => ({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: (tool as any)._mcpInputSchema ?? {
+          type: "object",
+          properties: tool.properties,
+          required: tool.required,
+        },
+      },
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // toolHandler override — routes to MCP instead of local funcs
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Handles tool-use blocks from the LLM response by calling the appropriate
+   * MCP server. Mirrors the {@link AgentTools#toolHandler} signature exactly
+   * so it works inside BedrockLLMAgent, AnthropicAgent, etc. without changes.
+   */
+  override async toolHandler(
+    response: any,
+    getToolUseBlock: (block: any) => any,
+    getToolName: (toolUseBlock: any) => string,
+    getToolId: (toolUseBlock: any) => string,
+    getInputData: (toolUseBlock: any) => any
+  ): Promise<AgentToolResult[]> {
+    await this.ensureConnected();
+
+    if (!response.content) {
+      throw new Error("No content blocks in response");
+    }
+
+    const toolResults: AgentToolResult[] = [];
+
+    for (const block of response.content) {
+      const toolUseBlock = getToolUseBlock(block);
+      if (!toolUseBlock) continue;
+
+      const toolName = getToolName(toolUseBlock);
+      const toolId = getToolId(toolUseBlock);
+      const inputData = getInputData(toolUseBlock);
+
+      const result = await this.callMCPTool(toolName, inputData);
+      toolResults.push(new AgentToolResult(toolId, result));
+    }
+
+    return toolResults;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  private async callMCPTool(toolName: string, inputData: any): Promise<string> {
+    const client = this.toolClientMap.get(toolName);
+    if (!client) {
+      return `MCP tool '${toolName}' not found`;
+    }
+
+    try {
+      const mcpResult = await client.callTool({
+        name: toolName,
+        arguments: inputData ?? {},
+      });
+
+      if (mcpResult.isError) {
+        const errorText = this.extractTextFromContent(mcpResult.content);
+        return `Error from MCP tool '${toolName}': ${errorText}`;
+      }
+
+      return this.extractTextFromContent(mcpResult.content);
+    } catch (error: any) {
+      return `Error calling MCP tool '${toolName}': ${error?.message ?? String(error)}`;
+    }
+  }
+
+  private extractTextFromContent(content: any): string {
+    if (!content) return "";
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+      return content
+        .map((item: any) => {
+          if (typeof item === "string") return item;
+          if (item?.type === "text") return item.text ?? "";
+          if (item?.text) return item.text;
+          return JSON.stringify(item);
+        })
+        .join("\n");
+    }
+    if (typeof content === "object" && content.text) return content.text;
+    return JSON.stringify(content);
+  }
+
+  /**
+   * Disconnect all MCP clients. Call this when the agent is no longer needed
+   * to cleanly shut down stdio child processes or SSE connections.
+   */
+  async disconnect(): Promise<void> {
+    for (const client of this.clients) {
+      try {
+        await client.close();
+      } catch {
+        // ignore errors during cleanup
+      }
+    }
+    this.clients = [];
+    this.toolClientMap.clear();
+    this.tools = [];
+    this.connected = false;
+  }
+}
+
+// Re-export for convenience
+export type { ConversationMessage };

--- a/typescript/tests/mcpToolProvider.test.ts
+++ b/typescript/tests/mcpToolProvider.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Unit tests for MCPToolProvider.
+ *
+ * All MCP SDK imports are mocked so no real server is required.
+ */
+
+// ---------------------------------------------------------------------------
+// Mock @modelcontextprotocol/sdk before any imports that might pull it in
+// ---------------------------------------------------------------------------
+
+const mockCallTool = jest.fn();
+const mockListTools = jest.fn();
+const mockConnect = jest.fn();
+const mockClose = jest.fn();
+
+class MockClient {
+  connect = mockConnect;
+  listTools = mockListTools;
+  callTool = mockCallTool;
+  close = mockClose;
+}
+
+class MockStdioTransport {
+  constructor(public opts: any) {}
+}
+
+class MockSSETransport {
+  constructor(public url: any, public opts: any) {}
+}
+
+jest.mock("@modelcontextprotocol/sdk/client/index.js", () => ({ Client: MockClient }), { virtual: true });
+jest.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({ StdioClientTransport: MockStdioTransport }), { virtual: true });
+jest.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({ SSEClientTransport: MockSSETransport }), { virtual: true });
+
+// ---------------------------------------------------------------------------
+// Subject under test
+// ---------------------------------------------------------------------------
+
+import { MCPToolProvider, MCPServerConfig } from "../src/tools/mcpToolProvider";
+import { AgentTools, AgentToolResult } from "../src/utils/tool";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const weatherTool = {
+  name: "get_weather",
+  description: "Returns weather for a location",
+  inputSchema: {
+    type: "object",
+    properties: {
+      location: { type: "string", description: "City name" },
+    },
+    required: ["location"],
+  },
+};
+
+const searchTool = {
+  name: "search_web",
+  description: "Search the web",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: { type: "string" },
+    },
+    required: ["query"],
+  },
+};
+
+function makeBedrockResponse(toolName: string, toolUseId: string, input: any) {
+  return {
+    role: "assistant",
+    content: [
+      {
+        toolUse: { name: toolName, toolUseId, input },
+      },
+    ],
+  };
+}
+
+// Bedrock extractor callbacks
+const bedrockGetToolUseBlock = (block: any) => block.toolUse ?? null;
+const bedrockGetToolName = (b: any) => b.name;
+const bedrockGetToolId = (b: any) => b.toolUseId;
+const bedrockGetInputData = (b: any) => b.input;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MCPToolProvider", () => {
+  let provider: MCPToolProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockConnect.mockResolvedValue(undefined);
+    mockClose.mockResolvedValue(undefined);
+    mockListTools.mockResolvedValue({ tools: [weatherTool] });
+    mockCallTool.mockResolvedValue({
+      isError: false,
+      content: [{ type: "text", text: "Sunny, 25°C" }],
+    });
+
+    provider = new MCPToolProvider([
+      { type: "stdio", command: "uvx", args: ["weather-server"] },
+    ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Inheritance
+  // -------------------------------------------------------------------------
+
+  it("should be an instance of AgentTools", () => {
+    expect(provider).toBeInstanceOf(AgentTools);
+  });
+
+  // -------------------------------------------------------------------------
+  // Lazy connection
+  // -------------------------------------------------------------------------
+
+  it("should not connect until ensureConnected is called", async () => {
+    expect(mockConnect).not.toHaveBeenCalled();
+    await provider.ensureConnected();
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should connect only once even with multiple ensureConnected calls", async () => {
+    await provider.ensureConnected();
+    await provider.ensureConnected();
+    await provider.ensureConnected();
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should populate this.tools after ensureConnected", async () => {
+    expect(provider.tools).toHaveLength(0);
+    await provider.ensureConnected();
+    expect(provider.tools).toHaveLength(1);
+    expect(provider.tools[0].name).toBe("get_weather");
+  });
+
+  // -------------------------------------------------------------------------
+  // toBedrockFormat
+  // -------------------------------------------------------------------------
+
+  it("toBedrockFormat returns tools in Bedrock toolSpec format", async () => {
+    const formatted = await provider.toBedrockFormat();
+    expect(formatted).toHaveLength(1);
+    const spec = formatted[0].toolSpec;
+    expect(spec.name).toBe("get_weather");
+    expect(spec.description).toBe("Returns weather for a location");
+    expect(spec.inputSchema.json).toEqual(weatherTool.inputSchema);
+  });
+
+  it("toBedrockFormat passes MCP inputSchema through unchanged", async () => {
+    await provider.ensureConnected();
+    const formatted = await provider.toBedrockFormat();
+    // The JSON Schema from MCP should be passed through directly
+    expect(formatted[0].toolSpec.inputSchema.json.properties.location).toEqual(
+      weatherTool.inputSchema.properties.location
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // toAnthropicFormat
+  // -------------------------------------------------------------------------
+
+  it("toAnthropicFormat returns tools in Anthropic format", async () => {
+    const formatted = await provider.toAnthropicFormat();
+    expect(formatted).toHaveLength(1);
+    expect(formatted[0].name).toBe("get_weather");
+    expect(formatted[0].input_schema).toEqual(weatherTool.inputSchema);
+  });
+
+  // -------------------------------------------------------------------------
+  // toOpenAIFormat
+  // -------------------------------------------------------------------------
+
+  it("toOpenAIFormat returns tools in OpenAI function-calling format", async () => {
+    const formatted = await provider.toOpenAIFormat();
+    expect(formatted).toHaveLength(1);
+    expect(formatted[0].type).toBe("function");
+    expect(formatted[0].function.name).toBe("get_weather");
+    expect(formatted[0].function.parameters).toEqual(weatherTool.inputSchema);
+  });
+
+  // -------------------------------------------------------------------------
+  // toolHandler — execution routing
+  // -------------------------------------------------------------------------
+
+  it("toolHandler calls the correct MCP tool and returns results", async () => {
+    const response = makeBedrockResponse("get_weather", "call-001", {
+      location: "Paris",
+    });
+
+    const results = await provider.toolHandler(
+      response,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+
+    expect(mockCallTool).toHaveBeenCalledWith({
+      name: "get_weather",
+      arguments: { location: "Paris" },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toBeInstanceOf(AgentToolResult);
+    expect(results[0].toolUseId).toBe("call-001");
+    expect(results[0].content).toBe("Sunny, 25°C");
+  });
+
+  it("toolHandler triggers lazy connection if not yet connected", async () => {
+    const response = makeBedrockResponse("get_weather", "call-002", {
+      location: "London",
+    });
+
+    expect(mockConnect).not.toHaveBeenCalled();
+    await provider.toolHandler(
+      response,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("toolHandler returns empty array when content has no tool-use blocks", async () => {
+    const response = {
+      role: "assistant",
+      content: [{ text: "Hello!" }],
+    };
+
+    const results = await provider.toolHandler(
+      response,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("toolHandler throws when response has no content", async () => {
+    await expect(
+      provider.toolHandler(
+        {},
+        bedrockGetToolUseBlock,
+        bedrockGetToolName,
+        bedrockGetToolId,
+        bedrockGetInputData
+      )
+    ).rejects.toThrow("No content blocks in response");
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling — isError from MCP
+  // -------------------------------------------------------------------------
+
+  it("toolHandler surfaces isError from MCP result as error string", async () => {
+    mockCallTool.mockResolvedValueOnce({
+      isError: true,
+      content: [{ type: "text", text: "Service unavailable" }],
+    });
+
+    const response = makeBedrockResponse("get_weather", "call-err", {
+      location: "Berlin",
+    });
+
+    const results = await provider.toolHandler(
+      response,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+
+    expect(results[0].content).toContain("Error from MCP tool 'get_weather'");
+    expect(results[0].content).toContain("Service unavailable");
+  });
+
+  it("toolHandler handles exception thrown by callTool", async () => {
+    mockCallTool.mockRejectedValueOnce(new Error("Connection lost"));
+
+    const response = makeBedrockResponse("get_weather", "call-exc", {
+      location: "Tokyo",
+    });
+
+    const results = await provider.toolHandler(
+      response,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+
+    expect(results[0].content).toContain("Error calling MCP tool");
+    expect(results[0].content).toContain("Connection lost");
+  });
+
+  it("toolHandler returns not-found message for unknown tool name", async () => {
+    await provider.ensureConnected();
+
+    const response = makeBedrockResponse("nonexistent_tool", "call-404", {});
+
+    const results = await provider.toolHandler(
+      response,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+
+    expect(results[0].content).toContain("not found");
+    expect(mockCallTool).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple servers — tool routing
+  // -------------------------------------------------------------------------
+
+  it("routes tools to the correct server when multiple servers are configured", async () => {
+    // Arrange: first listTools call returns weatherTool, second returns searchTool
+    mockListTools
+      .mockResolvedValueOnce({ tools: [weatherTool] })
+      .mockResolvedValueOnce({ tools: [searchTool] });
+
+    // callTool returns different results based on tool name
+    mockCallTool.mockImplementation((args: any) => {
+      if (args.name === "get_weather") {
+        return Promise.resolve({ isError: false, content: [{ type: "text", text: "Sunny" }] });
+      }
+      return Promise.resolve({ isError: false, content: [{ type: "text", text: "Search result" }] });
+    });
+
+    const multiProvider = new MCPToolProvider([
+      { type: "stdio", command: "uvx", args: ["weather-server"] },
+      { type: "sse", url: "http://localhost:3000/sse" },
+    ]);
+
+    await multiProvider.ensureConnected();
+    // Both servers contributed their tools
+    expect(multiProvider.tools).toHaveLength(2);
+    expect(multiProvider.tools.map((t) => t.name)).toContain("get_weather");
+    expect(multiProvider.tools.map((t) => t.name)).toContain("search_web");
+
+    // Call weather tool
+    const weatherResponse = makeBedrockResponse("get_weather", "w-1", { location: "NYC" });
+    const weatherResults = await multiProvider.toolHandler(
+      weatherResponse,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+    expect(weatherResults[0].content).toBe("Sunny");
+
+    // Call search tool
+    const searchResponse = makeBedrockResponse("search_web", "s-1", { query: "MCP" });
+    const searchResults = await multiProvider.toolHandler(
+      searchResponse,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+    expect(searchResults[0].content).toBe("Search result");
+  });
+
+  // -------------------------------------------------------------------------
+  // disconnect
+  // -------------------------------------------------------------------------
+
+  it("disconnect calls close on all clients and resets state", async () => {
+    await provider.ensureConnected();
+    expect(provider.tools).toHaveLength(1);
+
+    await provider.disconnect();
+
+    expect(mockClose).toHaveBeenCalledTimes(1);
+    expect(provider.tools).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // SSE transport
+  // -------------------------------------------------------------------------
+
+  it("creates SSEClientTransport for sse server config", async () => {
+    const sseProvider = new MCPToolProvider([
+      { type: "sse", url: "http://localhost:9000/sse", headers: { "x-api-key": "abc" } },
+    ]);
+
+    await sseProvider.ensureConnected();
+    // If we got here without error, SSE transport was constructed correctly
+    expect(mockConnect).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Config validation
+  // -------------------------------------------------------------------------
+
+  it("throws when stdio server config has no command", async () => {
+    const badProvider = new MCPToolProvider([
+      { type: "stdio" } as MCPServerConfig,
+    ]);
+
+    await expect(badProvider.ensureConnected()).rejects.toThrow(
+      "requires a 'command' field"
+    );
+  });
+
+  it("throws when sse server config has no url", async () => {
+    const badProvider = new MCPToolProvider([
+      { type: "sse" } as MCPServerConfig,
+    ]);
+
+    await expect(badProvider.ensureConnected()).rejects.toThrow(
+      "requires a 'url' field"
+    );
+  });
+});


### PR DESCRIPTION
## Issue Link (REQUIRED)

Fixes #299

## Summary

### Changes

Adds `MCPToolProvider` — a subclass of `AgentTools` that connects to one or more MCP servers (stdio or SSE transport) and exposes their tools transparently inside the existing `toolConfig` mechanism. No changes to any existing agent, classifier, or orchestrator.

- New file: `typescript/src/tools/mcpToolProvider.ts`
  - `MCPServerConfig` interface covering stdio (`command`, `args`, `env`) and SSE (`url`, `headers`) transports
  - `MCPToolProvider extends AgentTools` with lazy connection, tool caching, and routing back to the correct server per tool call
  - `toBedrockFormat()`, `toAnthropicFormat()`, `toOpenAIFormat()` — pass MCP's JSON Schema through directly
  - `isError` results from MCP surfaced as error strings to the model
  - `disconnect()` for clean shutdown
- `typescript/package.json`: `@modelcontextprotocol/sdk >=1.0.0` in `peerDependencies` (optional, never forced)
- `typescript/src/index.ts`: exports `MCPToolProvider` and `MCPServerConfig`
- 20 unit tests — all 132 suite tests passing, lint clean

### User experience

Before: no MCP support.

After:

```typescript
import { MCPToolProvider, BedrockLLMAgent } from "agent-squad";

const agent = new BedrockLLMAgent({
    name: "my-agent",
    description: "An agent with MCP tools",
    toolConfig: {
        tool: new MCPToolProvider([
            { type: "stdio", command: "uvx", args: ["my-mcp-server"] },
            { type: "sse", url: "http://localhost:3000/sse" },
        ])
    }
});
```

Install: `npm install agent-squad && npm install @modelcontextprotocol/sdk`

## Checklist

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] I have linked this PR to an existing issue (required)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.