### PR TITLE
feat(swift): reasoning effort — session-level + per-tool turn escalation

### DIFF
--- a/swift/README.md
+++ b/swift/README.md
@@ -312,6 +312,30 @@ keeps what the user actually heard. The built-in outputs measure this automatica
 > `duckingLevel: .min` to compensate. Never enable voice processing on the playback engine; it
 > belongs on capture only.
 
+## Reasoning effort (reasoning Realtime models)
+
+Reasoning-capable Realtime models (e.g. `gpt-realtime-2`) can "think" before each response; how
+much is a tunable — `RealtimeReasoningEffort`: `.minimal`/`.low`/`.medium`/`.high`/`.xhigh`
+(server default `.low`). `OpenAIVoiceAssistant` exposes it at two levels:
+
+```swift
+let assistant = OpenAIVoiceAssistant(
+    name: "advisor", transport: transport, tools: tools,
+    userId: "u1", sessionId: "s1",
+    reasoning: .low,                                    // session default for every response
+    toolReasoningEffort: ["get_insights": .medium]      // per-tool escalation (see below)
+)
+```
+
+`toolReasoningEffort` solves a latency/depth dilemma: you rarely know a turn needs deep reasoning
+*before* it starts — but the turn reveals itself by the tools it calls. When a turn calls a listed
+tool, every **subsequent** response of that turn is created with the mapped effort (highest wins
+if several match), so the response that *synthesizes* a heavyweight tool's payload thinks harder
+while quick lookups keep the session default. The escalation is per turn and resets when the turn
+completes.
+
+Leave both unset for non-reasoning models (e.g. `gpt-realtime-1.5`) — nothing is sent on the wire.
+
 ## Architecture
 
 Two peer runtimes share one set of contracts but not a control loop: a turn-based `Orchestrator`

--- a/swift/SKILL.md
+++ b/swift/SKILL.md
@@ -87,7 +87,11 @@ stream. `.final` is what the orchestrator persists. Inputs/messages are value ty
   Session tuning on both: `transcriptionModel` (the user's STT only), `turnDetection`
   (`.semanticVAD(eagerness:)` / `.serverVAD(threshold:…)` / `.disabled`), and `sessionOverrides`
   (deep-merged into the generated `session.update` last — the escape hatch for unmodeled keys like
-  `audio.input.noise_reduction`).
+  `audio.input.noise_reduction`). On `OpenAIVoiceAssistant` additionally
+  `reasoning: RealtimeReasoningEffort` (`.minimal`…`.xhigh`, session-wide, reasoning models like
+  gpt-realtime-2 only) and `toolReasoningEffort: [String: RealtimeReasoningEffort]` — turn-sticky
+  escalation: once a turn calls a listed tool, that turn's subsequent responses are created with
+  the mapped effort (highest wins), so payload synthesis thinks harder while lookups stay fast.
 
 ## Custom implementations
 

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
@@ -30,6 +30,8 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
     nonisolated let sampleRate: Int
     private let transcriptionModel: String
     private let turnDetection: RealtimeTurnDetection
+    private let reasoning: RealtimeReasoningEffort?
+    private let toolReasoningEffort: [String: RealtimeReasoningEffort]
     private let sessionOverrides: [String: JSONValue]
 
     // Per-turn state (cleared by `resetTurn`).
@@ -40,6 +42,10 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
     // A typed turn (`sendText`) replies text-only — so we don't announce `.speaking`, and the
     // tool→continue response stays text-only too.
     private var currentTurnIsTextOnly = false
+    // Turn-sticky reasoning escalation: once a turn calls a tool listed in `toolReasoningEffort`,
+    // every subsequent response of that turn is created with the mapped effort (highest wins) —
+    // the synthesis of a heavyweight tool's payload may span several tool→continue rounds.
+    private var turnReasoningEffort: RealtimeReasoningEffort?
     // Audio-relay gating: the spoken response is the bare agent turn, so track the current agent
     // response id and relay its audio, re-pointing on every `response.created` across the
     // tool→continue loop. On barge-in `currentResponseId` is cleared so late audio drops.
@@ -74,6 +80,8 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         sampleRate: Int = 24_000,
         transcriptionModel: String = "gpt-4o-mini-transcribe",
         turnDetection: RealtimeTurnDetection = .semanticVAD(),
+        reasoning: RealtimeReasoningEffort? = nil,
+        toolReasoningEffort: [String: RealtimeReasoningEffort] = [:],
         sessionOverrides: [String: JSONValue] = [:]
     ) {
         self.name = name
@@ -93,6 +101,8 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         self.sampleRate = sampleRate
         self.transcriptionModel = transcriptionModel
         self.turnDetection = turnDetection
+        self.reasoning = reasoning
+        self.toolReasoningEffort = toolReasoningEffort
         self.sessionOverrides = sessionOverrides
         (self.events, self.continuation) = AsyncStream.makeStream(of: RealtimeEvent.self)
     }
@@ -115,13 +125,19 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         RealtimeWire.sessionUpdate(
             model: model, instructions: instructions, voice: voice,
             language: language, tools: tools, sampleRate: sampleRate, agentOutput: modality.output,
-            transcriptionModel: transcriptionModel, turnDetection: turnDetection, overrides: sessionOverrides
+            transcriptionModel: transcriptionModel, turnDetection: turnDetection,
+            reasoning: reasoning, overrides: sessionOverrides
         )
     }
 
     func afterToolResult(name: String, result: ToolResult) {
         // A tool may advertise UI — surface it as a widget alongside the spoken reply.
         if let payload = result.ui { emit(.widget(payload)) }
+        // A configured tool escalates the rest of the turn's responses to its reasoning effort —
+        // the response that SYNTHESIZES this tool's payload is where the extra thinking pays off.
+        if let effort = toolReasoningEffort[name] {
+            turnReasoningEffort = max(turnReasoningEffort ?? effort, effort)
+        }
     }
 
     // MARK: - VoiceAssistant (turn brain)
@@ -217,8 +233,12 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         liveResponses.remove(id)
         if let calls = callsPerResponse[id], calls > 0 {    // this response called tools → continue the turn
             callsPerResponse[id] = nil
-            // Keep the continue response in the turn's modality — a typed turn stays text-only.
-            try? await transport.send(currentTurnIsTextOnly ? RealtimeWire.createResponse(output: .text) : RealtimeWire.createResponse())
+            // Keep the continue response in the turn's modality — a typed turn stays text-only —
+            // and carry the turn's escalated reasoning effort, if a configured tool set one.
+            try? await transport.send(RealtimeWire.createResponse(
+                output: currentTurnIsTextOnly ? .text : nil,
+                reasoning: turnReasoningEffort
+            ))
             return
         }
         // A response that called no tools is the spoken answer — the turn is complete.
@@ -265,6 +285,7 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         callsPerResponse.removeAll()
         fnNames.removeAll()
         currentTurnIsTextOnly = false   // next turn defaults to the session modality unless `sendText` opts in
+        turnReasoningEffort = nil       // reasoning escalation is per turn
         // liveResponses / currentResponseId / isSpeaking are managed by responseDone / interrupt.
     }
 

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeWire.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeWire.swift
@@ -21,6 +21,7 @@ enum RealtimeWire {
         agentOutput: RealtimeModality.Output = .text,
         transcriptionModel: String = "gpt-4o-mini-transcribe",
         turnDetection: RealtimeTurnDetection = .semanticVAD(),
+        reasoning: RealtimeReasoningEffort? = nil,
         overrides: [String: JSONValue] = [:]
     ) -> String {
         var transcription: [String: JSONValue] = ["model": .string(transcriptionModel)]
@@ -48,6 +49,7 @@ enum RealtimeWire {
             session["tools"] = .array(tools.map(functionSchema))
             session["tool_choice"] = .string("auto")
         }
+        if let reasoning { session["reasoning"] = .object(["effort": .string(reasoning.rawValue)]) }
         let merged = overrides.isEmpty
             ? JSONValue.object(session)
             : JSONValue.object(session).deepMerging(.object(overrides))
@@ -96,19 +98,26 @@ enum RealtimeWire {
         ])
     }
 
-    /// `response.create`. With no `output`, runs under the session config; pass `output: .text` to override this one response to text-only. Audio responses go through `presenterResponse`/`directResponse`.
-    static func createResponse(output: RealtimeModality.Output? = nil) -> String {
+    /// `response.create`. With no arguments, runs under the session config. Each parameter overrides
+    /// the session for this ONE response: `output: .text` forces a text-only reply, `reasoning` sets
+    /// the reasoning effort (reasoning models only), `instructions` REPLACES the session instructions
+    /// (it does not append). Audio responses go through `presenterResponse`/`directResponse`.
+    static func createResponse(output: RealtimeModality.Output? = nil,
+                               reasoning: RealtimeReasoningEffort? = nil,
+                               instructions: String? = nil) -> String {
+        var response: [String: JSONValue] = [:]
         switch output {
         case nil:
-            return frame(["type": .string("response.create")])
+            break
         case .text:
-            return frame([
-                "type": .string("response.create"),
-                "response": .object(["output_modalities": .array([.string("text")])]),
-            ])
+            response["output_modalities"] = .array([.string("text")])
         case .audio, .audioAndText:
             preconditionFailure("createResponse supports a text-only override; audio responses use presenterResponse/directResponse")
         }
+        if let reasoning { response["reasoning"] = .object(["effort": .string(reasoning.rawValue)]) }
+        if let instructions { response["instructions"] = .string(instructions) }
+        guard !response.isEmpty else { return frame(["type": .string("response.create")]) }
+        return frame(["type": .string("response.create"), "response": .object(response)])
     }
 
     /// The grounded presenter: out-of-band (`conversation:"none"`), fed only the curated message.

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
@@ -49,6 +49,27 @@ public enum RealtimeTurnDetection: Sendable, Equatable {
     }
 }
 
+/// Reasoning effort for reasoning-capable Realtime models (e.g. `gpt-realtime-2`) — how much the
+/// model "thinks" before producing a response. The server default is `low`. Settable at the session
+/// level and per response (`response.create` overrides the session for that one response).
+/// Non-reasoning models (e.g. `gpt-realtime-1.5`) don't support it — leave unset there.
+/// `Comparable` by depth so callers can take the max of several requested efforts.
+public enum RealtimeReasoningEffort: String, Sendable, Equatable, Comparable {
+    case minimal, low, medium, high, xhigh
+
+    private var depth: Int {
+        switch self {
+        case .minimal: return 0
+        case .low: return 1
+        case .medium: return 2
+        case .high: return 3
+        case .xhigh: return 4
+        }
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.depth < rhs.depth }
+}
+
 /// An event from a realtime voice session. Its **own** type, deliberately not `AgentEvent`:
 /// continuous audio, server-driven turn boundaries and barge-in don't fit the turn-based contract.
 /// Errors arrive in-band as `.error`, so the stream is non-throwing.

--- a/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
@@ -429,4 +429,88 @@ import Testing
         await session.stop()
         #expect(transport.closed)
     }
+
+    // MARK: - Reasoning effort
+
+    private func reasoningEffort(of frame: String) -> String? {
+        guard let obj = try? JSONSerialization.jsonObject(with: Data(frame.utf8)) as? [String: Any],
+              let response = obj["response"] as? [String: Any],
+              let reasoning = response["reasoning"] as? [String: Any] else { return nil }
+        return reasoning["effort"] as? String
+    }
+
+    @Test func configuredToolEscalatesTheContinuationReasoning() async throws {
+        let transport = MockRealtimeTransport()
+        let session = OpenAIVoiceAssistant(name: "voice", transport: transport, tools: oddsTools(),
+                                           userId: "u1", sessionId: "s1",
+                                           toolReasoningEffort: ["odds": .medium])
+        try await session.start()
+
+        await session.sendText("should I bet on PSG?")
+        transport.push(responseCreated("r1"))
+        transport.push(funcArgs("r1", "c1", "odds"))     // the configured tool runs
+        transport.push(responseDone("r1"))               // → continuation
+
+        await eventually { sentTypes(transport).filter { $0 == "response.create" }.count >= 2 }
+        let creates = transport.sent.filter { frameType(of: $0) == "response.create" }
+        // The initial response runs at the session default; the response that synthesizes the
+        // tool's payload thinks at the configured effort.
+        #expect(reasoningEffort(of: creates[0]) == nil)
+        #expect(reasoningEffort(of: try #require(creates.last)) == "medium")
+    }
+
+    @Test func reasoningEscalationIsTurnStickyAndResetsOnTheNextTurn() async throws {
+        let transport = MockRealtimeTransport()
+        let session = OpenAIVoiceAssistant(name: "voice", transport: transport, tools: oddsTools(),
+                                           userId: "u1", sessionId: "s1",
+                                           toolReasoningEffort: ["odds": .medium])
+        try await session.start()
+
+        await session.sendText("should I bet on PSG?")
+        transport.push(responseCreated("r1"))
+        transport.push(funcArgs("r1", "c1", "odds"))     // escalates the turn
+        transport.push(responseDone("r1"))               // continuation 1
+        transport.push(responseCreated("r2"))
+        transport.push(funcArgs("r2", "c2", "odds"))     // a second tool round, same turn
+        transport.push(responseDone("r2"))               // continuation 2
+        transport.push(responseCreated("r3"))
+        transport.push(responseDone("r3"))               // no tools → turn complete, escalation resets
+
+        await eventually { sentTypes(transport).filter { $0 == "response.create" }.count >= 3 }
+        await session.sendText("and the score?")         // a fresh turn
+        await eventually { sentTypes(transport).filter { $0 == "response.create" }.count >= 4 }
+
+        let creates = transport.sent.filter { frameType(of: $0) == "response.create" }
+        #expect(reasoningEffort(of: creates[1]) == "medium")   // sticky across the turn's rounds…
+        #expect(reasoningEffort(of: creates[2]) == "medium")
+        #expect(reasoningEffort(of: creates[3]) == nil)        // …but never leaks into the next turn
+    }
+
+    @Test func unconfiguredToolLeavesTheContinuationAtTheSessionDefault() async throws {
+        let transport = MockRealtimeTransport()
+        let session = session(transport)   // no toolReasoningEffort
+        try await session.start()
+
+        transport.push(responseCreated("r1"))
+        transport.push(funcArgs("r1", "c1", "odds"))
+        transport.push(responseDone("r1"))
+
+        await eventually { sentTypes(transport).contains("response.create") }
+        let creates = transport.sent.filter { frameType(of: $0) == "response.create" }
+        #expect(creates.allSatisfy { reasoningEffort(of: $0) == nil })   // wire unchanged for existing users
+    }
+
+    @Test func sessionLevelReasoningRidesTheSessionUpdate() async throws {
+        let transport = MockRealtimeTransport()
+        let session = OpenAIVoiceAssistant(name: "voice", transport: transport, tools: oddsTools(),
+                                           userId: "u1", sessionId: "s1", reasoning: .high)
+        try await session.start()
+
+        await eventually { sentTypes(transport).contains("session.update") }
+        let update = try #require(transport.sent.first { $0.contains("session.update") })
+        let obj = try #require(try? JSONSerialization.jsonObject(with: Data(update.utf8)) as? [String: Any])
+        let sess = try #require(obj["session"] as? [String: Any])
+        let reasoning = try #require(sess["reasoning"] as? [String: Any])
+        #expect(reasoning["effort"] as? String == "high")
+    }
 }


### PR DESCRIPTION
## Why

Reasoning-capable Realtime models (`gpt-realtime-2`) accept a reasoning effort at the session level and per response (`response.create → response.reasoning.effort`, enum `minimal|low|medium|high|xhigh`, server default `low`). The package had no way to send either — every response of every consumer runs at lookup-grade effort, including the ones that synthesize a heavyweight tool payload into an answer.

## What

- **`RealtimeReasoningEffort`** — `minimal/low/medium/high/xhigh`, `Comparable` by depth.
- **`RealtimeWire.sessionUpdate(reasoning:)`** — session-level effort in the `session.update` frame.
- **`RealtimeWire.createResponse(output:reasoning:instructions:)`** — per-response overrides; `instructions` REPLACES the session prompt for that one response (documented Realtime semantics), included here as the second half of the same per-response override surface.
- **`OpenAIVoiceAssistant(reasoning:toolReasoningEffort:)`** — session default plus **turn-sticky per-tool escalation**: a turn rarely announces it needs deep reasoning up front, but it reveals itself by the tools it calls. Once a listed tool runs, the turn's subsequent `response.create`s carry the mapped effort (highest wins across tools; resets on turn end) — so the response synthesizing an analytics/aggregate tool's payload thinks harder while quick lookups keep the session default.

Opt-in everywhere: nothing is sent on the wire unless configured — zero change for existing consumers and non-reasoning models (`gpt-realtime-1.5`).

## Validation

- 4 new tests (escalation on the continuation frame, turn-stickiness + reset, unconfigured tool leaves the wire unchanged, session-level frame); full suite 375/375 green.
- Field-tested in a consumer A/B benchmark (same match/queries, only the effort changed): advice-answer quality up, a chained-fetch stall fixed, and the `medium` latency premium was below tool-latency noise.

## Docs

README gains a "Reasoning effort" section; SKILL.md session-tuning entry updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)