### PR TITLE
feat(swift): tracePerTurn + traceName for live per-turn export

### DIFF
--- a/docs/src/content/docs/swift/voice/built-in/openai-grounded-voice.md
+++ b/docs/src/content/docs/swift/voice/built-in/openai-grounded-voice.md
@@ -20,6 +20,8 @@ public actor OpenAIGroundedVoiceAssistant: VoiceAssistant {
         store: (any ChatStorage)? = nil,
         tracer: any Tracer = OSLogTracer(),
         traceTranscripts: Bool = true,
+        tracePerTurn: Bool = false,
+        traceName: String? = nil,
         maxMessages: Int? = ChatStorageDefaults.maxMessages,
         modality: RealtimeModality = RealtimeModality(),
         curator: any ToolOutputCurator = .dataBlock,
@@ -49,6 +51,8 @@ public actor OpenAIGroundedVoiceAssistant: VoiceAssistant {
 | `store` | `nil` | Enables history seeding and persistence; see [Storage overview](/agent-squad/swift/storage/overview/) |
 | `tracer` | `OSLogTracer()` | Span sink; see [Tracing overview](/agent-squad/swift/tracing/overview/) |
 | `traceTranscripts` | `true` | When `false`, span input/output fields are omitted |
+| `tracePerTurn` | `false` | When `true`, each turn is its own root trace instead of nesting under one `voice.session` root — so a backend that finalizes a trace on its root's end (e.g. LangSmith) renders each turn as it completes, mid-session. Turns still group into a conversation via shared span metadata (e.g. a `thread_id`), not a shared trace id |
+| `traceName` | `nil` | Overrides the root trace name with a human label (e.g. the match teams). `nil` keeps the defaults: `voice.session` (session root) / `voice.turn` (per-turn root) |
 | `maxMessages` | `ChatStorageDefaults.maxMessages` | Cap on replayed history items |
 | `modality` | `RealtimeModality()` (speech in / audio out) | Controls the event mix; see [Voice overview](/agent-squad/swift/voice/overview/) |
 | `curator` | `.dataBlock` | Shapes tool output fed to the presenter; see [UI overview](/agent-squad/swift/ui/overview/) |

--- a/docs/src/content/docs/swift/voice/built-in/openai-voice.md
+++ b/docs/src/content/docs/swift/voice/built-in/openai-voice.md
@@ -20,6 +20,8 @@ public actor OpenAIVoiceAssistant: VoiceAssistant {
         store: (any ChatStorage)? = nil,
         tracer: any Tracer = OSLogTracer(),
         traceTranscripts: Bool = true,
+        tracePerTurn: Bool = false,
+        traceName: String? = nil,
         maxMessages: Int? = ChatStorageDefaults.maxMessages,
         modality: RealtimeModality = RealtimeModality(),
         instructions: String = OpenAIVoiceAssistant.defaultInstructions,
@@ -46,6 +48,8 @@ public actor OpenAIVoiceAssistant: VoiceAssistant {
 | `store` | `nil` | Enables history seeding and persistence; see [Storage overview](/agent-squad/swift/storage/overview/) |
 | `tracer` | `OSLogTracer()` | Span sink; see [Tracing overview](/agent-squad/swift/tracing/overview/) |
 | `traceTranscripts` | `true` | When `false`, span input/output fields are omitted while structure and token counts still flow |
+| `tracePerTurn` | `false` | When `true`, each turn is its own root trace instead of nesting under one `voice.session` root — so a backend that finalizes a trace on its root's end (e.g. LangSmith) renders each turn as it completes, mid-session. Turns still group into a conversation via shared span metadata (e.g. a `thread_id`), not a shared trace id |
+| `traceName` | `nil` | Overrides the root trace name with a human label (e.g. the match teams). `nil` keeps the defaults: `voice.session` (session root) / `voice.turn` (per-turn root) |
 | `maxMessages` | `ChatStorageDefaults.maxMessages` | Cap on replayed history items |
 | `modality` | `RealtimeModality()` (speech in / audio out) | Controls the event mix; see [Voice overview](/agent-squad/swift/voice/overview/) |
 | `instructions` | `defaultInstructions` | System prompt — tells the model to use tools and reply concisely in speech |

--- a/docs/src/content/docs/swift/voice/overview.md
+++ b/docs/src/content/docs/swift/voice/overview.md
@@ -175,7 +175,9 @@ When `store` is provided at init, `start()` replays prior turns from `ChatStorag
 
 ## Tracing
 
-Each session is one trace: a `voice.session` root span opened on the first turn, with a `voice.turn` child per turn. Tool calls appear as `tool.<name>` children of the turn. Token usage (including per-modality audio token breakdown) is attached to the generation span inside each turn. Set `traceTranscripts: false` to keep spoken content off the trace while span structure and token counts still flow. See [Tracing overview](/agent-squad/swift/tracing/overview/).
+By default each session is one trace: a `voice.session` root span opened on the first turn, with a `voice.turn` child per turn. Tool calls appear as `tool.<name>` children of the turn. Token usage (including per-modality audio token breakdown) is attached to the generation span inside each turn. Set `traceTranscripts: false` to keep spoken content off the trace while span structure and token counts still flow.
+
+Set `tracePerTurn: true` to instead root **each turn** as its own trace (no shared `voice.session`): a backend that finalizes a trace when its root span ends (e.g. LangSmith) then renders each turn the moment it completes, rather than only after the session closes. The turns still group into one conversation via shared span metadata (e.g. a `thread_id` a custom `Redactor` stamps on every span), not a shared trace id. Use `traceName` to label the root trace with something human (e.g. the match teams) instead of `voice.session` / `voice.turn`. See [Tracing overview](/agent-squad/swift/tracing/overview/).
 
 ---
 

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
@@ -22,6 +22,8 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
     nonisolated let store: (any ChatStorage)?
     nonisolated let maxMessages: Int?
     nonisolated let traceTranscripts: Bool
+    nonisolated let tracePerTurn: Bool
+    nonisolated let traceName: String?
     private let curator: any ToolOutputCurator
     private let presenterPrompt: PresenterPrompt
     private let presenterInput: PresenterInput
@@ -71,6 +73,8 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
         store: (any ChatStorage)? = nil,
         tracer: any Tracer = OSLogTracer(),
         traceTranscripts: Bool = true,
+        tracePerTurn: Bool = false,
+        traceName: String? = nil,
         maxMessages: Int? = ChatStorageDefaults.maxMessages,
         modality: RealtimeModality = RealtimeModality(),
         curator: any ToolOutputCurator = .dataBlock,
@@ -95,6 +99,8 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
         self.maxMessages = maxMessages
         self.tracer = tracer
         self.traceTranscripts = traceTranscripts
+        self.tracePerTurn = tracePerTurn
+        self.traceName = traceName
         self.modality = modality
         self.curator = curator
         self.presenterPrompt = presenterPrompt

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIRealtimeSession.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIRealtimeSession.swift
@@ -23,6 +23,13 @@ protocol OpenAIRealtimeSession: Actor {
     nonisolated var store: (any ChatStorage)? { get }
     nonisolated var maxMessages: Int? { get }
     nonisolated var traceTranscripts: Bool { get }
+    /// When true, each turn is its own root trace instead of a child of one `voice.session` root.
+    /// Lets backends that finalize a trace on its root's end (e.g. LangSmith) render turns live
+    /// mid-session; turns still group into a conversation via any shared metadata (e.g. a thread id).
+    nonisolated var tracePerTurn: Bool { get }
+    /// Overrides the root trace's name (e.g. a human label like the match teams). `nil` keeps the
+    /// defaults: `voice.session` for the session root, `voice.turn` for a per-turn root.
+    nonisolated var traceName: String? { get }
     nonisolated var model: String { get }
     nonisolated var voice: String { get }
     nonisolated var language: String? { get }
@@ -103,14 +110,18 @@ extension OpenAIRealtimeSession {
         traceTranscripts && !text.isEmpty ? .string(text) : nil
     }
 
-    /// Open a `voice.turn` child of the session root, lazily opening the root on first use.
-    /// The root carries the conversation's `modality` marker and lives until `stop()`.
+    /// Open the turn's span. By default a `voice.turn` child of a lazily-opened `voice.session` root
+    /// (the whole conversation is one trace, the root carrying the `modality` marker and living until
+    /// `stop()`). With `tracePerTurn`, each turn is instead its own root — no session root is opened —
+    /// so it exports the moment the turn ends (grouping into a conversation is then left to shared
+    /// metadata, e.g. a thread id, rather than a shared trace). `traceName` overrides the root name.
     func openTurnSpan() -> (any SpanHandle)? {
+        let marker: JSONValue = .object(["modality": .string(modality.traceMarker)])
+        if tracePerTurn {
+            return tracer.startTrace(name: traceName ?? "voice.turn", userId: userId, sessionId: sessionId, metadata: marker)
+        }
         if sessionSpan == nil {
-            sessionSpan = tracer.startTrace(
-                name: "voice.session", userId: userId, sessionId: sessionId,
-                metadata: .object(["modality": .string(modality.traceMarker)])
-            )
+            sessionSpan = tracer.startTrace(name: traceName ?? "voice.session", userId: userId, sessionId: sessionId, metadata: marker)
         }
         return sessionSpan?.span("voice.turn", input: nil)
     }

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
@@ -23,6 +23,8 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
     nonisolated let store: (any ChatStorage)?
     nonisolated let maxMessages: Int?
     nonisolated let traceTranscripts: Bool
+    nonisolated let tracePerTurn: Bool
+    nonisolated let traceName: String?
     private let instructions: String
     nonisolated let model: String
     nonisolated let voice: String
@@ -71,6 +73,8 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         store: (any ChatStorage)? = nil,
         tracer: any Tracer = OSLogTracer(),
         traceTranscripts: Bool = true,
+        tracePerTurn: Bool = false,
+        traceName: String? = nil,
         maxMessages: Int? = ChatStorageDefaults.maxMessages,
         modality: RealtimeModality = RealtimeModality(),
         instructions: String = OpenAIVoiceAssistant.defaultInstructions,
@@ -93,6 +97,8 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         self.maxMessages = maxMessages
         self.tracer = tracer
         self.traceTranscripts = traceTranscripts
+        self.tracePerTurn = tracePerTurn
+        self.traceName = traceName
         self.modality = modality
         self.instructions = instructions
         self.model = model

--- a/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
@@ -326,6 +326,41 @@ import Testing
         #expect(tracer.recorder.ended.filter { $0 == root.id }.count == 1)
     }
 
+    @Test func tracePerTurnRootsEachTurnAndUsesTraceName() async throws {
+        let transport = MockRealtimeTransport()
+        let tracer = StructureTracer()
+        // Per-turn mode with a caller-provided trace name (e.g. the match teams).
+        let session = OpenAIVoiceAssistant(name: "voice", transport: transport, tools: oddsTools(),
+                                           userId: "u1", sessionId: "s1", tracer: tracer,
+                                           tracePerTurn: true, traceName: "PSG - OM")
+        try await session.start()
+
+        for (rid, q, a) in [("r1", "first?", "one"), ("r2", "second?", "two")] {
+            transport.push(userSaid(q))
+            transport.push(responseCreated(rid))
+            transport.push(audioTranscriptDone(rid, a))
+            transport.push(responseDone(rid))
+            await eventually { tracer.recorder.opened.filter { $0.name == "PSG - OM" }.count
+                == (rid == "r1" ? 1 : 2) }
+        }
+
+        let nodes = tracer.recorder.opened
+        let roots = nodes.filter { $0.name == "PSG - OM" }
+        #expect(nodes.filter { $0.name == "voice.session" }.isEmpty)         // no shared session root
+        #expect(roots.count == 2)                                           // one root trace per turn
+        #expect(roots.allSatisfy { $0.parentId == nil })                    // each turn is a trace root
+        #expect(roots.allSatisfy { $0.metadata == .object(["modality": .string("audio")]) })  // marker moved to the turn root
+        #expect(Set(roots.map(\.traceId)).count == 2)                       // two distinct traces
+        // Each turn's children (the `response` generation) share their own turn's trace id.
+        for root in roots {
+            let children = nodes.filter { $0.parentId == root.id }
+            #expect(!children.isEmpty)
+            #expect(children.allSatisfy { $0.traceId == root.traceId })
+        }
+        #expect(roots.allSatisfy { tracer.recorder.ended.contains($0.id) })  // each turn root ends on turn completion (before stop)
+        await session.stop()
+    }
+
     @Test func framesAfterStopDoNotReopenTheSessionTrace() async throws {
         let transport = MockRealtimeTransport()
         let tracer = StructureTracer()


### PR DESCRIPTION
## Why

The realtime voice runtimes model a whole conversation as **one trace**: a `voice.session` root is opened lazily on the first turn and only ends at `stop()`, with each turn nested under it. Backends that finalize a trace when its **root span ends** (e.g. LangSmith) therefore can't render a conversation until the chat is closed — mid-session the turn/child spans arrive as orphans under a root that hasn't ended. A consumer app hitting a LangSmith OTLP sink sees nothing until teardown.

## What

Two additive, defaulted options on `OpenAIVoiceAssistant` and `OpenAIGroundedVoiceAssistant` (through the shared `OpenAIRealtimeSession`):

- **`tracePerTurn: Bool = false`** — root each turn as its own trace instead of nesting under one `voice.session`. Each turn then exports the instant it ends. Turns still group into a conversation via shared span **metadata** (e.g. a `thread_id` the app injects on every span) rather than a shared trace id — this is the standard LangSmith "threads" model (turn = trace, grouped by thread).
- **`traceName: String? = nil`** — override the root trace name with a human label (e.g. the match teams). Falls back to `voice.session` (session root) / `voice.turn` (per-turn root).

## Safety / compatibility

- Defaults preserve today's behavior exactly (one conversation = one trace). All existing tests unchanged and green.
- Nothing reads the shared session `traceId` (no usage rollup, no deep-link), so per-turn roots break no accounting; `stop()` / `flush()` / `shutdown()` are unchanged. `endSession()` is a no-op for the session root in per-turn mode (none is opened).
- The `modality` marker moves onto the turn root in per-turn mode (preserved, not lost).

## Tests

Adds `tracePerTurnRootsEachTurnAndUsesTraceName`: two turns → zero `voice.session`, two `voice.turn` roots (named via `traceName`) each with `parentId == nil`, two distinct trace ids, children sharing their own turn's trace id, and each turn root ended before `stop()`. Mirrors the existing `turnsNestUnderOneSessionRootSharingItsTraceId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)