### PR TITLE
feat(swift): surface realtime error message + failed response status

### DIFF
--- a/swift/SKILL.md
+++ b/swift/SKILL.md
@@ -127,7 +127,10 @@ signatures live in `Sources/AgentSquad/`.
   termination. `OSLogTracer` logs no payloads. `Redaction` hashes ids + clips strings but does **not**
   pattern-scrub PII — supply a custom `Redactor` for that.
 - **Realtime** is a peer runtime, not an agent; its `events` stream is non-throwing; needs
-  `NSMicrophoneUsageDescription`; always `stop()`.
+  `NSMicrophoneUsageDescription`; always `stop()`. In-band failures arrive as
+  `.error(code:message:)` — `code` is the API's machine code (e.g. `rate_limit_exceeded`) or
+  `response_failed` when a response ends with `status: "failed"`; `message` is the human-readable
+  detail for logs, not for verbatim display.
 - **Barge-in truncation**: on interrupt the session sends `conversation.item.truncate` so the
   server drops the unheard audio + transcript from context (OpenAI docs' WebSocket procedure).
   Automatic when wired by `RealtimeRuntime` with the built-in outputs; a custom `AudioOutput`

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
@@ -225,15 +225,21 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
                 presenterId = id
                 spokenResponseIsInBand = role == "direct"
             }
-        case .responseDone(let id, let usage):
-            await responseDone(id, usage: usage)
-        case .error(let code):
+        case .responseDone(let id, let usage, let status):
+            await responseDone(id, usage: usage, status: status)
+        case .error(let code, let message):
             if code == "response_cancel_not_active" { return }   // benign barge-in race
-            emit(.error(code ?? "realtime error"))
+            emit(.error(code: code, message: message ?? code ?? "realtime error"))
         }
     }
 
-    private func responseDone(_ id: String, usage: RealtimeUsage?) async {
+    private func responseDone(_ id: String, usage: RealtimeUsage?, status: RealtimeResponseStatus?) async {
+        if let status, status.isFailure {
+            // The response died server-side (gatherer, presenter, or direct alike) — presenting or
+            // continuing from it would hang the turn. Close it and hand the app the failure in-band.
+            failTurn(responseId: id, detail: status.detail)
+            return
+        }
         if presenterResponses.contains(id) {
             presenterResponses.remove(id)
             if id == presenterId {   // the response we're hearing finished cleanly
@@ -309,6 +315,23 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
         let frame = RealtimeWire.directResponse(instructions: directInstructions, output: modality.output, voice: voice)
         resetTurn()   // before the await — see present()
         try? await transport.send(frame)
+    }
+
+    /// A response ended `failed`: close the turn (span included), surface the failure in-band, and
+    /// return the session to its resting state — the app decides whether to retry. Clears the
+    /// pending presenter pair too: there is no reply to persist.
+    private func failTurn(responseId id: String, detail: String?) {
+        presenterResponses.remove(id)
+        if id == presenterId { presenterId = nil }
+        presenterActive = false
+        callsPerResponse[id] = nil
+        truncation.reset()
+        endTurn(error: nil)
+        emit(.error(code: "response_failed", message: detail ?? "response failed"))
+        emit(.state(.listening))   // same resting state a clean finish announces
+        resetTurn()
+        pendingUserText = ""
+        replyText = ""
     }
 
     // MARK: - Turn lifecycle

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
@@ -226,17 +226,23 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
             liveResponses.insert(id)
             currentResponseId = id
             isSpeaking = true
-        case .responseDone(let id, let usage):
-            await responseDone(id, usage: usage)
-        case .error(let code):
+        case .responseDone(let id, let usage, let status):
+            await responseDone(id, usage: usage, status: status)
+        case .error(let code, let message):
             if code == "response_cancel_not_active" { return }   // benign barge-in race
-            emit(.error(code ?? "realtime error"))
+            emit(.error(code: code, message: message ?? code ?? "realtime error"))
         }
     }
 
-    private func responseDone(_ id: String, usage: RealtimeUsage?) async {
+    private func responseDone(_ id: String, usage: RealtimeUsage?, status: RealtimeResponseStatus?) async {
         guard liveResponses.contains(id) else { return }   // unknown / stale (cancelled) response
         liveResponses.remove(id)
+        if let status, status.isFailure {
+            // The response died server-side (no `error` event accompanies this) — continuing the
+            // tool loop would hang the turn. Close it and hand the app the failure in-band.
+            failTurn(responseId: id, detail: status.detail)
+            return
+        }
         if let calls = callsPerResponse[id], calls > 0 {    // this response called tools → continue the turn
             callsPerResponse[id] = nil
             // Keep the continue response in the turn's modality — a typed turn stays text-only —
@@ -271,6 +277,19 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         emit(.state(.listening))
         resetTurn()
         await persist(user: user, reply: reply)
+    }
+
+    /// A response ended `failed`: close the turn (span included), surface the failure in-band, and
+    /// return the session to its resting state — the app decides whether to retry.
+    private func failTurn(responseId id: String, detail: String?) {
+        callsPerResponse[id] = nil
+        if id == currentResponseId { currentResponseId = nil }
+        isSpeaking = false
+        truncation.reset()
+        endTurn(error: nil)
+        emit(.error(code: "response_failed", message: detail ?? "response failed"))
+        emit(.state(.listening))   // same resting state a clean finish announces
+        resetTurn()
     }
 
     // MARK: - Turn lifecycle

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeWire.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/RealtimeWire.swift
@@ -205,6 +205,22 @@ enum RealtimeWire {
         }
     }
 
+    /// The response's final status + a one-line detail. `failed` carries `status_details.error`
+    /// (`type`/`code` — the API puts no message there); `cancelled`/`incomplete` carry
+    /// `status_details.reason` (`turn_detected`, `client_cancelled`, `max_output_tokens`,
+    /// `content_filter`).
+    private static func responseStatus(_ response: Envelope.ResponseObject) -> RealtimeResponseStatus? {
+        guard let status = response.status else { return nil }
+        let detail = response.statusDetails.flatMap { details -> String? in
+            if let error = details.error {
+                let joined = [error.type, error.code].compactMap { $0 }.joined(separator: ": ")
+                return joined.isEmpty ? nil : joined
+            }
+            return details.reason
+        }
+        return RealtimeResponseStatus(status: status, detail: detail)
+    }
+
     private static func functionSchema(_ tool: AgentTool) -> JSONValue {
         .object([
             "type": .string("function"),
@@ -235,9 +251,9 @@ enum RealtimeWire {
                     outputAudioTokens: usage.outputTokenDetails?.audioTokens,
                     cachedInputTokens: usage.inputTokenDetails?.cachedTokens
                 )
-            })
+            }, status: event.response.flatMap(responseStatus))
         case "error":
-            return .error(code: event.error?.code)
+            return .error(code: event.error?.code, message: event.error?.message)
         case "response.function_call_arguments.done":
             return .functionCallArguments(responseId: event.responseId ?? "", callId: event.callId ?? "", name: event.name, arguments: event.arguments ?? "{}")
         case "response.output_item.added":
@@ -297,7 +313,23 @@ enum RealtimeWire {
             let id: String?
             let metadata: Metadata?
             let usage: Usage?
+            let status: String?
+            let statusDetails: StatusDetails?
+            enum CodingKeys: String, CodingKey {
+                case id, metadata, usage, status
+                case statusDetails = "status_details"
+            }
             struct Metadata: Decodable { let role: String? }
+            /// Why the response ended: `failed` populates `error` (type/code only — no message on
+            /// this object), `cancelled`/`incomplete` populate `reason`.
+            struct StatusDetails: Decodable {
+                let reason: String?
+                let error: StatusError?
+                struct StatusError: Decodable {
+                    let type: String?
+                    let code: String?
+                }
+            }
             // Scalar totals feed the tracer's `usage(...)`; the per-modality breakdown
             // (`input_token_details.audio_tokens`/`.cached_tokens`, `output_token_details.audio_tokens`)
             // rides span metadata — see `RealtimeUsage`.
@@ -332,7 +364,12 @@ enum RealtimeWire {
             let name: String?
             enum CodingKeys: String, CodingKey { case type, id, name; case callId = "call_id" }
         }
-        struct ErrorObject: Decodable { let code: String? }
+        /// The GA `error` event's payload: `message` is required on the wire and is the only
+        /// human-readable detail the server sends — dropping it leaves consumers a bare code.
+        struct ErrorObject: Decodable {
+            let code: String?
+            let message: String?
+        }
     }
 }
 
@@ -349,8 +386,17 @@ enum ServerEvent: Sendable, Equatable {
     case audioTranscriptDelta(responseId: String, text: String)
     case audioTranscriptDone(responseId: String, text: String)
     case responseCreated(id: String, role: String?)
-    case responseDone(id: String, usage: RealtimeUsage?)
-    case error(code: String?)
+    case responseDone(id: String, usage: RealtimeUsage?, status: RealtimeResponseStatus?)
+    case error(code: String?, message: String?)
+}
+
+/// A response's final status from `response.done`. `isFailure` is the turn-killing case the
+/// sessions act on; `cancelled` (barge-in) and `incomplete` (max tokens / content filter, the
+/// audio still played) end turns through their normal paths.
+struct RealtimeResponseStatus: Sendable, Equatable {
+    let status: String   // completed | cancelled | failed | incomplete | in_progress
+    let detail: String?  // failed → status_details.error (type: code); cancelled/incomplete → reason
+    var isFailure: Bool { status == "failed" }
 }
 
 /// Token accounting from a Realtime `response.done`: scalar totals plus the per-modality breakdown.

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
@@ -81,7 +81,11 @@ public enum RealtimeEvent: Sendable {
     /// PCM16 @ 24 kHz to play (only for the response currently playing — the session drops stale audio on `interrupt()`). Drain promptly into a bounded playback channel.
     case audio(Data)
     case audioDone(interrupted: Bool)               // flush playback (barge-in or natural end)
-    case error(String)
+    /// A recoverable in-band failure: a server `error` event (`code` = the API's machine code, e.g.
+    /// `rate_limit_exceeded`), a response that ended `failed` (`code` = `response_failed`), or —
+    /// PR 2 — a dead transport (`code` = `transport_closed`). `message` is the human-readable
+    /// detail, always non-empty; log it, don't show it verbatim.
+    case error(code: String?, message: String)
 }
 
 /// A long-lived, bidirectional voice session (e.g. OpenAI Realtime). A peer of `Orchestrator`, not

--- a/swift/Tests/AgentSquadTests/OpenAIGroundedVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIGroundedVoiceAssistantTests.swift
@@ -520,4 +520,51 @@ import Testing
         try? await Task.sleep(for: .milliseconds(20))
         #expect(store.saved.isEmpty)   // a barged-in presenter produces no persisted pair
     }
+
+    // MARK: - Failed responses
+
+    @Test func failedGathererResponseEmitsErrorInsteadOfPresenting() async throws {
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let session = session(transport, tools: oddsTools())
+        log.start(session)
+        try await session.start()
+
+        transport.push(userSaid("odds?"))
+        transport.push(responseCreated("r1"))
+        transport.push(funcArgs("r1", "c1", "odds"))
+        transport.push(responseDone("r1"))       // tools → continue
+        transport.push(responseFailed("r2"))     // the continue died server-side
+
+        await eventually { !log.errors.isEmpty }
+        #expect(log.errorCodes == ["response_failed"])
+        #expect(log.errors == ["server_error: internal_error"])   // status_details.error, decoded
+        #expect(log.states.last == .listening)
+        // The turn never presented: the only response.create is the tool-continue one.
+        #expect(sentTypes(transport).filter { $0 == "response.create" }.count == 1)
+        #expect(!transport.sent.contains { $0.contains(#""role":"presenter""#) })
+    }
+
+    @Test func failedPresenterResponseSurfacesAndDoesNotPersist() async throws {
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let store = RecordingStore()
+        let session = session(transport, tools: oddsTools(), store: store)
+        log.start(session)
+        try await session.start()
+
+        transport.push(userSaid("odds?"))
+        transport.push(responseCreated("r1"))
+        transport.push(funcArgs("r1", "c1", "odds"))
+        transport.push(responseDone("r1"))
+        transport.push(responseDone("r2"))                        // settled → present()
+        transport.push(responseCreated("p1", role: "presenter"))
+        transport.push(responseFailed("p1"))                      // the presenter died mid-reply
+
+        await eventually { !log.errors.isEmpty }
+        #expect(log.errorCodes == ["response_failed"])
+        #expect(log.states.last == .listening)
+        try? await Task.sleep(for: .milliseconds(20))
+        #expect(store.saved.isEmpty)   // no reply was spoken — nothing to persist
+    }
 }

--- a/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
@@ -548,4 +548,37 @@ import Testing
         let reasoning = try #require(sess["reasoning"] as? [String: Any])
         #expect(reasoning["effort"] as? String == "high")
     }
+
+    @Test func serverErrorForwardsCodeAndMessage() async throws {
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let session = session(transport)
+        log.start(session)
+        try await session.start()
+
+        transport.push(serverError("rate_limit_exceeded", message: "Rate limit reached for the model."))
+        await eventually { !log.errors.isEmpty }
+        // The human-readable message survives to the app; the machine code rides alongside.
+        #expect(log.errors == ["Rate limit reached for the model."])
+        #expect(log.errorCodes == ["rate_limit_exceeded"])
+    }
+
+    @Test func failedResponseEmitsErrorAndDoesNotContinueTheTurn() async throws {
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let session = session(transport)
+        log.start(session)
+        try await session.start()
+
+        transport.push(responseCreated("r1"))
+        transport.push(funcArgs("r1", "c1", "odds"))   // tools called — a healthy done would continue
+        transport.push(responseFailed("r1"))           // …but the response died server-side
+
+        await eventually { !log.errors.isEmpty }
+        #expect(log.errorCodes == ["response_failed"])
+        #expect(log.errors == ["server_error: internal_error"])   // status_details.error, decoded
+        #expect(log.states.last == .listening)                     // back to the resting state
+        // No tool-continue response was created off the failed response.
+        #expect(!sentTypes(transport).contains("response.create"))
+    }
 }

--- a/swift/Tests/AgentSquadTests/RealtimeTestSupport.swift
+++ b/swift/Tests/AgentSquadTests/RealtimeTestSupport.swift
@@ -44,7 +44,8 @@ final class EventLog: @unchecked Sendable {
     var presenterTexts: [String] { all.compactMap { if case .presenterText(let t, _) = $0 { return t } else { return nil } } }
     var widgets: [UIPayload] { all.compactMap { if case .widget(let p) = $0 { return p } else { return nil } } }
     var audioDones: [Bool] { all.compactMap { if case .audioDone(let i) = $0 { return i } else { return nil } } }
-    var errors: [String] { all.compactMap { if case .error(let m) = $0 { return m } else { return nil } } }
+    var errors: [String] { all.compactMap { if case .error(_, let m) = $0 { return m } else { return nil } } }
+    var errorCodes: [String?] { all.compactMap { if case .error(let c, _) = $0 { return .some(c) } else { return nil } } }
     var audioCount: Int { all.filter(\.isAudio).count }
 }
 
@@ -188,6 +189,16 @@ func responseDone(_ id: String, inputTokens: Int? = nil, outputTokens: Int? = ni
         return #"{"type":"response.done","response":{"id":"\#(id)","usage":{"input_tokens":\#(i),"output_tokens":\#(o)}}}"#
     }
     return #"{"type":"response.done","response":{"id":"\#(id)"}}"#
+}
+
+func responseFailed(_ id: String, errorType: String = "server_error", errorCode: String? = "internal_error") -> String {
+    let error = errorCode.map { #"{"type":"\#(errorType)","code":"\#($0)"}"# } ?? #"{"type":"\#(errorType)"}"#
+    return #"{"type":"response.done","response":{"id":"\#(id)","status":"failed","status_details":{"type":"failed","error":\#(error)}}}"#
+}
+
+func serverError(_ code: String?, message: String) -> String {
+    let codeJSON = code.map { #""\#($0)""# } ?? "null"
+    return #"{"type":"error","error":{"type":"invalid_request_error","code":\#(codeJSON),"message":"\#(message)"}}"#
 }
 
 func responseCreated(_ id: String, role: String? = nil) -> String {

--- a/swift/Tests/AgentSquadTests/RealtimeWireTests.swift
+++ b/swift/Tests/AgentSquadTests/RealtimeWireTests.swift
@@ -211,16 +211,40 @@ import Testing
         #expect(RealtimeWire.decode(#"{"type":"response.output_text.delta","response_id":"r1","delta":"x"}"#) == .outputTextDelta(responseId: "r1", text: "x"))
         #expect(RealtimeWire.decode(#"{"type":"response.text.delta","response_id":"r1","delta":"x"}"#) == .outputTextDelta(responseId: "r1", text: "x"))
         #expect(RealtimeWire.decode(#"{"type":"response.created","response":{"id":"p1","metadata":{"role":"presenter"}}}"#) == .responseCreated(id: "p1", role: "presenter"))
-        #expect(RealtimeWire.decode(#"{"type":"response.done","response":{"id":"r1"}}"#) == .responseDone(id: "r1", usage: nil))
+        #expect(RealtimeWire.decode(#"{"type":"response.done","response":{"id":"r1"}}"#) == .responseDone(id: "r1", usage: nil, status: nil))
         #expect(RealtimeWire.decode(#"{"type":"response.done","response":{"id":"r1","usage":{"input_tokens":12,"output_tokens":34}}}"#)
-            == .responseDone(id: "r1", usage: RealtimeUsage(inputTokens: 12, outputTokens: 34, inputAudioTokens: nil, outputAudioTokens: nil, cachedInputTokens: nil)))
+            == .responseDone(id: "r1", usage: RealtimeUsage(inputTokens: 12, outputTokens: 34, inputAudioTokens: nil, outputAudioTokens: nil, cachedInputTokens: nil), status: nil))
         // Per-field tolerance: a usage object missing one count decodes that field to nil, not a failure.
         #expect(RealtimeWire.decode(#"{"type":"response.done","response":{"id":"r1","usage":{"input_tokens":12}}}"#)
-            == .responseDone(id: "r1", usage: RealtimeUsage(inputTokens: 12, outputTokens: nil, inputAudioTokens: nil, outputAudioTokens: nil, cachedInputTokens: nil)))
+            == .responseDone(id: "r1", usage: RealtimeUsage(inputTokens: 12, outputTokens: nil, inputAudioTokens: nil, outputAudioTokens: nil, cachedInputTokens: nil), status: nil))
         // The per-modality breakdown (audio / cached) is decoded from the nested token-detail objects.
         #expect(RealtimeWire.decode(#"{"type":"response.done","response":{"id":"r1","usage":{"input_tokens":1240,"output_tokens":820,"input_token_details":{"audio_tokens":1000,"cached_tokens":200},"output_token_details":{"audio_tokens":700}}}}"#)
-            == .responseDone(id: "r1", usage: RealtimeUsage(inputTokens: 1240, outputTokens: 820, inputAudioTokens: 1000, outputAudioTokens: 700, cachedInputTokens: 200)))
-        #expect(RealtimeWire.decode(#"{"type":"error","error":{"code":"response_cancel_not_active"}}"#) == .error(code: "response_cancel_not_active"))
+            == .responseDone(id: "r1", usage: RealtimeUsage(inputTokens: 1240, outputTokens: 820, inputAudioTokens: 1000, outputAudioTokens: 700, cachedInputTokens: 200), status: nil))
+        #expect(RealtimeWire.decode(#"{"type":"error","error":{"code":"response_cancel_not_active"}}"#) == .error(code: "response_cancel_not_active", message: nil))
+    }
+
+    @Test func decodesErrorEventDetail() {
+        // The GA `error` payload: `message` is required on the wire, `code` is nullable. Both must
+        // survive decode — the message is the only human-readable detail the server ever sends.
+        #expect(RealtimeWire.decode(#"{"type":"error","error":{"type":"invalid_request_error","code":"invalid_value","message":"Invalid value: 'text'.","param":"item.content[0].type","event_id":"evt_1"}}"#)
+            == .error(code: "invalid_value", message: "Invalid value: 'text'."))
+        #expect(RealtimeWire.decode(#"{"type":"error","error":{"type":"server_error","code":null,"message":"The server had an error."}}"#)
+            == .error(code: nil, message: "The server had an error."))
+    }
+
+    @Test func decodesResponseDoneStatus() {
+        // `failed` carries `status_details.error` (type/code — the API puts no message there).
+        #expect(RealtimeWire.decode(#"{"type":"response.done","response":{"id":"r1","status":"failed","status_details":{"type":"failed","error":{"type":"server_error","code":"internal_error"}}}}"#)
+            == .responseDone(id: "r1", usage: nil, status: RealtimeResponseStatus(status: "failed", detail: "server_error: internal_error")))
+        // A failed response missing the nested error object still surfaces the status.
+        #expect(RealtimeWire.decode(#"{"type":"response.done","response":{"id":"r1","status":"failed"}}"#)
+            == .responseDone(id: "r1", usage: nil, status: RealtimeResponseStatus(status: "failed", detail: nil)))
+        // `cancelled`/`incomplete` carry `status_details.reason`, and are not failures.
+        let cancelled = RealtimeWire.decode(#"{"type":"response.done","response":{"id":"r1","status":"cancelled","status_details":{"type":"cancelled","reason":"turn_detected"}}}"#)
+        #expect(cancelled == .responseDone(id: "r1", usage: nil, status: RealtimeResponseStatus(status: "cancelled", detail: "turn_detected")))
+        if case .responseDone(_, _, let status?) = cancelled! { #expect(!status.isFailure) } else { Issue.record("expected a status") }
+        #expect(RealtimeWire.decode(#"{"type":"response.done","response":{"id":"r1","status":"completed"}}"#)
+            == .responseDone(id: "r1", usage: nil, status: RealtimeResponseStatus(status: "completed", detail: nil)))
     }
 
     @Test func ignoresUnhandledEvents() {

--- a/swift/Tests/AgentSquadTests/VoiceAssistantContractTests.swift
+++ b/swift/Tests/AgentSquadTests/VoiceAssistantContractTests.swift
@@ -45,7 +45,7 @@ import Testing
     @Test func inBandErrorDoesNotTerminateStream() async throws {
         let session = StubSession()
         try await session.start()
-        session.emit(.error("transient"))
+        session.emit(.error(code: nil, message: "transient"))
         session.emit(.state(.ready))
         await session.stop()
 


### PR DESCRIPTION
Fixes #573

## Why

Realtime failures reach consumers as almost nothing today:

- The GA `error` event's `message` — **required on the wire**, and the only human-readable detail the server sends (the docs explicitly recommend logging it) — is dropped at decode: `RealtimeWire.ErrorObject` kept only `code`. Apps are left string-matching bare codes and showing generic "something went wrong" bubbles.
- `response.done`'s `status` / `status_details` were not decoded at all, so a response that ended `failed` was indistinguishable from a clean turn end. Worse, if that response had called tools, the session would send the tool-continue `response.create` off the corpse and the turn would hang — consumer apps have watchdog timers as scar tissue for exactly this.

## What

- **`RealtimeWire`**: decode `error.{code,message}` and `response.{status,status_details}` (shapes verified against the official Realtime OpenAPI spec: `failed` carries `status_details.error.{type,code}`; `cancelled`/`incomplete` carry `reason`). New internal `RealtimeResponseStatus`.
- **`RealtimeEvent.error`** is now `.error(code: String?, message: String)` — code for classification, message for logs.
- **Both sessions**: forward code+message on server `error` events (benign `response_cancel_not_active` still swallowed); a `response.done` with `status: "failed"` now closes the turn via a new `failTurn`, emits `.error(code: "response_failed", message: <status_details.error>)` and returns to `.listening` — no tool-continue off a failed response, no hung turn. `cancelled`/`incomplete` keep their existing paths (barge-in / partial output are not failures).

## Breaking change

`RealtimeEvent.error(String)` → `.error(code: String?, message: String)`: one switch case to update per consumer. Deliberate — a shim would freeze the string-only shape this PR exists to fix.

## Tests

Decode fixtures for error detail + all statuses; session tests for message forwarding and failed responses (single-LLM: no continue off a failed response; grounded: failed gatherer never presents, failed presenter persists nothing). 388 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)