### PR TITLE
fix(swift): mark a failed realtime turn's span as errored

### DIFF
--- a/swift/SKILL.md
+++ b/swift/SKILL.md
@@ -125,7 +125,9 @@ signatures live in `Sources/AgentSquad/`.
 - **Storage**: `FileChatStorage` (JSON, iOS 16+, scopes per-call by `userId`/`sessionId`/`agentId` — e.g. `sessionId` to isolate per match) or `DeviceChatStorage` (SwiftData, iOS 17+, bound to one `userId`). Both default to Library/Caches (disposable). `InMemoryChatStorage` (iOS 16+) is non-persistent and holds one conversation — construct it empty or seeded with a prior conversation to load one into a session. Wrap any store in `TransformingChatStorage` to scrub/redact before persistence; prefer redacting over returning `nil` (dropping one side of an exchange can make the store skip its counterpart via the consecutive-same-role guard).
 - **Tracing lifecycle**: nothing drains the tracer for you — flush on background, shut down on
   termination. `OSLogTracer` logs no payloads. `Redaction` hashes ids + clips strings but does **not**
-  pattern-scrub PII — supply a custom `Redactor` for that.
+  pattern-scrub PII — supply a custom `Redactor` for that. A realtime turn that ends on a failed
+  response closes its turn span **with the failure** (`status: .error`, `error` = `response_failed: <detail>`),
+  so the errored run is exported and flagged, not recorded as a silent success.
 - **Realtime** is a peer runtime, not an agent; its `events` stream is non-throwing; needs
   `NSMicrophoneUsageDescription`; always `stop()`. In-band failures arrive as
   `.error(code:message:)` — `code` is the API's machine code (e.g. `rate_limit_exceeded`) or

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
@@ -326,8 +326,10 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
         presenterActive = false
         callsPerResponse[id] = nil
         truncation.reset()
-        endTurn(error: nil)
-        emit(.error(code: "response_failed", message: detail ?? "response failed"))
+        let message = detail ?? "response failed"
+        // Close the turn span WITH the failure so the exported run is flagged errored, not `.ok`.
+        endTurn(error: RealtimeTurnError(code: "response_failed", message: message))
+        emit(.error(code: "response_failed", message: message))
         emit(.state(.listening))   // same resting state a clean finish announces
         resetTurn()
         pendingUserText = ""

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
@@ -286,8 +286,10 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
         if id == currentResponseId { currentResponseId = nil }
         isSpeaking = false
         truncation.reset()
-        endTurn(error: nil)
-        emit(.error(code: "response_failed", message: detail ?? "response failed"))
+        let message = detail ?? "response failed"
+        // Close the turn span WITH the failure so the exported run is flagged errored, not `.ok`.
+        endTurn(error: RealtimeTurnError(code: "response_failed", message: message))
+        emit(.error(code: "response_failed", message: message))
         emit(.state(.listening))   // same resting state a clean finish announces
         resetTurn()
     }

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/VoiceAssistant.swift
@@ -88,6 +88,19 @@ public enum RealtimeEvent: Sendable {
     case error(code: String?, message: String)
 }
 
+/// A realtime turn that ended abnormally, recorded on the turn's trace span via `endTurn(error:)`
+/// so the exported run is flagged `.error` (not silently `.ok`). Mirrors the `.error` event handed
+/// to the app: `code` is the machine code (`response_failed`, or a server error's own code),
+/// `message` the human-readable detail. Internal — the app sees the failure as `RealtimeEvent.error`;
+/// this only exists to carry the failure into the span. Its `debugDescription` (what
+/// `ProcessingTracer` stringifies via `String(reflecting:)`) is `"<code>: <message>"`.
+struct RealtimeTurnError: Error, Equatable, CustomStringConvertible, CustomDebugStringConvertible {
+    let code: String?
+    let message: String
+    var description: String { code.map { "\($0): \(message)" } ?? message }
+    var debugDescription: String { description }
+}
+
 /// A long-lived, bidirectional voice session (e.g. OpenAI Realtime). A peer of `Orchestrator`, not
 /// an `AgentProtocol` — it owns its own control loop and reuses only the shared `ToolProvider` /
 /// `ChatStorage` / `Tracer` contracts.

--- a/swift/Tests/AgentSquadTests/OpenAIGroundedVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIGroundedVoiceAssistantTests.swift
@@ -526,7 +526,8 @@ import Testing
     @Test func failedGathererResponseEmitsErrorInsteadOfPresenting() async throws {
         let transport = MockRealtimeTransport()
         let log = EventLog()
-        let session = session(transport, tools: oddsTools())
+        let tracer = RecordingTracer()
+        let session = session(transport, tools: oddsTools(), tracer: tracer)
         log.start(session)
         try await session.start()
 
@@ -543,6 +544,12 @@ import Testing
         // The turn never presented: the only response.create is the tool-continue one.
         #expect(sentTypes(transport).filter { $0 == "response.create" }.count == 1)
         #expect(!transport.sent.contains { $0.contains(#""role":"presenter""#) })
+
+        // The turn span is closed WITH the failure, so the exported run is flagged errored, not `.ok`.
+        await eventually { tracer.recorder.ended.contains("voice.turn") }
+        let spanError = try #require(tracer.recorder.error("voice.turn"))
+        #expect(spanError.contains("response_failed"))
+        #expect(spanError.contains("server_error: internal_error"))
     }
 
     @Test func failedPresenterResponseSurfacesAndDoesNotPersist() async throws {

--- a/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
@@ -566,7 +566,8 @@ import Testing
     @Test func failedResponseEmitsErrorAndDoesNotContinueTheTurn() async throws {
         let transport = MockRealtimeTransport()
         let log = EventLog()
-        let session = session(transport)
+        let tracer = RecordingTracer()
+        let session = session(transport, tracer: tracer)
         log.start(session)
         try await session.start()
 
@@ -580,5 +581,11 @@ import Testing
         #expect(log.states.last == .listening)                     // back to the resting state
         // No tool-continue response was created off the failed response.
         #expect(!sentTypes(transport).contains("response.create"))
+
+        // The turn span is closed WITH the failure, so the exported run is flagged errored, not `.ok`.
+        await eventually { tracer.recorder.ended.contains("voice.turn") }
+        let spanError = try #require(tracer.recorder.error("voice.turn"))
+        #expect(spanError.contains("response_failed"))
+        #expect(spanError.contains("server_error: internal_error"))
     }
 }

--- a/swift/Tests/AgentSquadTests/RealtimeTestSupport.swift
+++ b/swift/Tests/AgentSquadTests/RealtimeTestSupport.swift
@@ -62,10 +62,11 @@ final class RecordingTracer: Tracer, @unchecked Sendable {
         private var _output: [String: JSONValue] = [:]
         private var _usage: [String: (Int?, Int?)] = [:]
         private var _metadata: [String: JSONValue] = [:]
+        private var _errored: [String: String] = [:]
         func open(_ n: String, input: JSONValue? = nil) { lock.withLock { _opened.append(n); if let input { _input[n] = input } } }
         func setInput(_ n: String, _ input: JSONValue) { lock.withLock { _input[n] = input } }
         func setMetadata(_ n: String, _ metadata: JSONValue) { lock.withLock { _metadata[n] = metadata } }
-        func close(_ n: String, output: JSONValue?) { lock.withLock { _ended.append(n); if let output { _output[n] = output } } }
+        func close(_ n: String, output: JSONValue?, error: (any Error)?) { lock.withLock { _ended.append(n); if let output { _output[n] = output }; if let error { _errored[n] = String(reflecting: error) } } }
         func record(_ n: String, prompt: Int?, completion: Int?) { lock.withLock { _usage[n] = (prompt, completion) } }
         var opened: [String] { lock.withLock { _opened } }
         var ended: [String] { lock.withLock { _ended } }
@@ -73,6 +74,9 @@ final class RecordingTracer: Tracer, @unchecked Sendable {
         func output(_ n: String) -> JSONValue? { lock.withLock { _output[n] } }
         func usage(_ n: String) -> (Int?, Int?)? { lock.withLock { _usage[n] } }
         func metadata(_ n: String) -> JSONValue? { lock.withLock { _metadata[n] } }
+        /// The stringified error a span was closed with (nil if it ended cleanly) — mirrors what
+        /// `ProcessingTracer` records, so the exported run's `.error` status can be asserted.
+        func error(_ n: String) -> String? { lock.withLock { _errored[n] } }
     }
     final class Span: GenerationHandle, @unchecked Sendable {
         let id: String
@@ -82,7 +86,7 @@ final class RecordingTracer: Tracer, @unchecked Sendable {
         func generation(_ name: String, model: String, input: JSONValue?) -> any GenerationHandle { recorder.open(name, input: input); return Span(id: name, recorder: recorder) }
         func setInput(_ input: JSONValue) { recorder.setInput(id, input) }
         func setMetadata(_ metadata: JSONValue) { recorder.setMetadata(id, metadata) }
-        func end(output: JSONValue?, error: (any Error)?) { recorder.close(id, output: output) }
+        func end(output: JSONValue?, error: (any Error)?) { recorder.close(id, output: output, error: error) }
         func usage(promptTokens: Int?, completionTokens: Int?) { recorder.record(id, prompt: promptTokens, completion: completionTokens) }
     }
     let recorder = Recorder()


### PR DESCRIPTION
## Problem

A realtime response that ended `status: "failed"` closed its turn span via `endTurn(error: nil)`. `BatchSpanProcessor` records `status: error == nil ? .ok : .error`, so the failed turn was exported **flagged `.ok`** — it showed up in LangSmith as a *successful* run, indistinguishable from a clean finish. (#571 fixed the earlier bug where the span never closed at all; this fixes how it's labelled.)

## Fix

- Add an internal `RealtimeTurnError` (code + message; `debugDescription` = `"<code>: <message>"`, which is what `ProcessingTracer` stringifies via `String(reflecting:)`).
- `failTurn` in both `OpenAIVoiceAssistant` and `OpenAIGroundedVoiceAssistant` now passes it to `endTurn(error:)` instead of `nil`, so the exported run is `status: .error` with the detail.

No public API change — the app still sees the failure as `RealtimeEvent.error`; this only affects what the trace span records.

## Tests

`RecordingTracer` now captures the error a span was closed with. The failed-response tests assert the `voice.turn` span carries `response_failed: server_error: internal_error`. Full suite green (382 tests).

## Context

Part of making OpenAI realtime errors visible in LangSmith for the Betclic AI companion. Companion PR (stacked): *close the turn span on an in-flight realtime error*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)