### PR TITLE
fix(swift): close the turn span on an in-flight realtime error

### DIFF
--- a/swift/SKILL.md
+++ b/swift/SKILL.md
@@ -125,9 +125,11 @@ signatures live in `Sources/AgentSquad/`.
 - **Storage**: `FileChatStorage` (JSON, iOS 16+, scopes per-call by `userId`/`sessionId`/`agentId` — e.g. `sessionId` to isolate per match) or `DeviceChatStorage` (SwiftData, iOS 17+, bound to one `userId`). Both default to Library/Caches (disposable). `InMemoryChatStorage` (iOS 16+) is non-persistent and holds one conversation — construct it empty or seeded with a prior conversation to load one into a session. Wrap any store in `TransformingChatStorage` to scrub/redact before persistence; prefer redacting over returning `nil` (dropping one side of an exchange can make the store skip its counterpart via the consecutive-same-role guard).
 - **Tracing lifecycle**: nothing drains the tracer for you — flush on background, shut down on
   termination. `OSLogTracer` logs no payloads. `Redaction` hashes ids + clips strings but does **not**
-  pattern-scrub PII — supply a custom `Redactor` for that. A realtime turn that ends on a failed
-  response closes its turn span **with the failure** (`status: .error`, `error` = `response_failed: <detail>`),
-  so the errored run is exported and flagged, not recorded as a silent success.
+  pattern-scrub PII — supply a custom `Redactor` for that. A realtime turn that ends on a failure —
+  a `response.done status: "failed"`, or a server `error` event while a turn is in flight — closes
+  its turn span **with the failure** (`status: .error`, `error` = `<code>: <detail>`), so the errored
+  run is exported and flagged immediately, not recorded as a silent success or leaked open until
+  `stop()`. A server error with no active turn has no span to attribute — it is surfaced only.
 - **Realtime** is a peer runtime, not an agent; its `events` stream is non-throwing; needs
   `NSMicrophoneUsageDescription`; always `stop()`. In-band failures arrive as
   `.error(code:message:)` — `code` is the API's machine code (e.g. `rate_limit_exceeded`) or

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIGroundedVoiceAssistant.swift
@@ -229,7 +229,24 @@ public actor OpenAIGroundedVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant
             await responseDone(id, usage: usage, status: status)
         case .error(let code, let message):
             if code == "response_cancel_not_active" { return }   // benign barge-in race
-            emit(.error(code: code, message: message ?? code ?? "realtime error"))
+            let detail = message ?? code ?? "realtime error"
+            // A server error ends the turn in flight (no `response.done` follows one). Close its span
+            // WITH the error so the failure is traced now — flagged errored — instead of leaking the
+            // span open until stop(). No active turn (a session-level error, or one before the first
+            // `response.created`): nothing to attribute, so surface it only — see failTurn for the
+            // failed-`response.done` path.
+            if turnSpan != nil {
+                presenterId = nil
+                presenterActive = false
+                presenterResponses.removeAll()
+                truncation.reset()
+                endTurn(error: RealtimeTurnError(code: code, message: detail))
+                resetTurn()
+                pendingUserText = ""
+                replyText = ""
+                emit(.state(.listening))   // recovered to the resting state, as failTurn does
+            }
+            emit(.error(code: code, message: detail))
         }
     }
 

--- a/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
+++ b/swift/Sources/AgentSquad/Runtimes/Realtime/OpenAIVoiceAssistant.swift
@@ -230,7 +230,21 @@ public actor OpenAIVoiceAssistant: OpenAIRealtimeSession, VoiceAssistant {
             await responseDone(id, usage: usage, status: status)
         case .error(let code, let message):
             if code == "response_cancel_not_active" { return }   // benign barge-in race
-            emit(.error(code: code, message: message ?? code ?? "realtime error"))
+            let detail = message ?? code ?? "realtime error"
+            // A server error ends the turn in flight (no `response.done` follows one). Close its span
+            // WITH the error so the failure is traced now — flagged errored — instead of leaking the
+            // span open until stop(). No active turn (a session-level error, or one before the first
+            // `response.created`): nothing to attribute, so surface it only — see failTurn for the
+            // failed-`response.done` path.
+            if turnSpan != nil {
+                isSpeaking = false
+                currentResponseId = nil
+                truncation.reset()
+                endTurn(error: RealtimeTurnError(code: code, message: detail))
+                resetTurn()
+                emit(.state(.listening))   // recovered to the resting state, as failTurn does
+            }
+            emit(.error(code: code, message: detail))
         }
     }
 

--- a/swift/Tests/AgentSquadTests/OpenAIGroundedVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIGroundedVoiceAssistantTests.swift
@@ -574,4 +574,26 @@ import Testing
         try? await Task.sleep(for: .milliseconds(20))
         #expect(store.saved.isEmpty)   // no reply was spoken — nothing to persist
     }
+
+    @Test func serverErrorInFlightClosesTheTurnSpanWithError() async throws {
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let tracer = RecordingTracer()
+        let session = session(transport, tools: oddsTools(), tracer: tracer)
+        log.start(session)
+        try await session.start()
+
+        transport.push(userSaid("odds?"))
+        transport.push(responseCreated("r1"))   // the gatherer turn is in flight — the span is open
+        transport.push(serverError("rate_limit_exceeded", message: "Rate limit reached for the model."))
+
+        await eventually { !log.errors.isEmpty }
+        #expect(log.errorCodes == ["rate_limit_exceeded"])
+        #expect(log.states.last == .listening)
+        // The in-flight turn span is closed WITH the error, not leaked open until stop().
+        await eventually { tracer.recorder.ended.contains("voice.turn") }
+        let spanError = try #require(tracer.recorder.error("voice.turn"))
+        #expect(spanError.contains("rate_limit_exceeded"))
+        #expect(spanError.contains("Rate limit reached for the model."))
+    }
 }

--- a/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
+++ b/swift/Tests/AgentSquadTests/OpenAIVoiceAssistantTests.swift
@@ -552,7 +552,8 @@ import Testing
     @Test func serverErrorForwardsCodeAndMessage() async throws {
         let transport = MockRealtimeTransport()
         let log = EventLog()
-        let session = session(transport)
+        let tracer = RecordingTracer()
+        let session = session(transport, tracer: tracer)
         log.start(session)
         try await session.start()
 
@@ -561,6 +562,29 @@ import Testing
         // The human-readable message survives to the app; the machine code rides alongside.
         #expect(log.errors == ["Rate limit reached for the model."])
         #expect(log.errorCodes == ["rate_limit_exceeded"])
+        // No turn was in flight (no `response.created`), so there is no span to attribute — none opened.
+        #expect(!tracer.recorder.opened.contains("voice.turn"))
+    }
+
+    @Test func serverErrorInFlightClosesTheTurnSpanWithError() async throws {
+        let transport = MockRealtimeTransport()
+        let log = EventLog()
+        let tracer = RecordingTracer()
+        let session = session(transport, tracer: tracer)
+        log.start(session)
+        try await session.start()
+
+        transport.push(responseCreated("r1"))   // a turn is now in flight — the span is open
+        transport.push(serverError("rate_limit_exceeded", message: "Rate limit reached for the model."))
+
+        await eventually { !log.errors.isEmpty }
+        #expect(log.errorCodes == ["rate_limit_exceeded"])
+        #expect(log.states.last == .listening)   // recovered to the resting state
+        // The in-flight turn span is closed WITH the error, not leaked open until stop().
+        await eventually { tracer.recorder.ended.contains("voice.turn") }
+        let spanError = try #require(tracer.recorder.error("voice.turn"))
+        #expect(spanError.contains("rate_limit_exceeded"))
+        #expect(spanError.contains("Rate limit reached for the model."))
     }
 
     @Test func failedResponseEmitsErrorAndDoesNotContinueTheTurn() async throws {


### PR DESCRIPTION
## Problem

A server `error` event (rate limit, invalid request, oversized tool output, …) arriving **while a turn was in flight** only emitted `.error` to the app — it never closed the turn's trace span. No `response.done` follows a server `error` (the two paths are disjoint), so the span leaked open until `stop()`: with `tracePerTurn` the turn **never exported**; otherwise it exported late and flagged `.ok`.

These are exactly the errors the iOS companion surfaces as its generic "technical hiccup" bubble — and they produced **no LangSmith trace at the moment of failure**, which is the symptom we set out to fix.

## Fix

In the `.error` handler of both `OpenAIVoiceAssistant` and `OpenAIGroundedVoiceAssistant`: when a turn span is open, close it **with** the error (`RealtimeTurnError` from the base PR), reset the turn state, and announce `.listening` — the same recovery `failTurn` already performs for a failed `response.done`.

- The benign `response_cancel_not_active` barge-in race is still swallowed, unchanged.
- A server error with **no active turn** (session-level, or before the first `response.created`) has no span to attribute, so it is surfaced only. Documented as a known limitation; fabricating a span for it is a separate design question.

## Tests

- In-flight server error closes `voice.turn` carrying `rate_limit_exceeded: <message>` and recovers to `.listening`, in both assistants.
- A no-active-turn server error opens no span.

Full suite green (384 tests).

## Note

**Stacked on #575** (`fix/mark-failed-voice-turn-errored`) — it introduces the `RealtimeTurnError` type this PR uses. Review/merge #575 first; this PR's base is that branch, so it currently shows only its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)