### PR TITLE
docs(examples): add Swift ChatGPT-style chat sample (GroundedAgent + tool UIs)

### DIFF
--- a/examples/swift/ChatGPTStyleChat/.gitignore
+++ b/examples/swift/ChatGPTStyleChat/.gitignore
@@ -1,0 +1,8 @@
+# Xcode user state — never commit
+xcuserdata/
+*.xcuserstate
+DerivedData/
+.DS_Store
+
+# Resolved package pins are machine-local for a local package reference
+ChatGPTStyleChat.xcodeproj/project.xcworkspace/

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat.xcodeproj/project.pbxproj
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat.xcodeproj/project.pbxproj
@@ -1,0 +1,343 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A100000000000000000000B9 /* AgentSquad in Frameworks */ = {isa = PBXBuildFile; productRef = A100000000000000000000B8 /* AgentSquad */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A100000000000000000000A6 /* ChatGPTStyleChat */ = {isa = PBXFileSystemSynchronizedRootGroup; path = ChatGPTStyleChat; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A100000000000000000000A8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A100000000000000000000B9 /* AgentSquad in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A100000000000000000000A2 = {
+			isa = PBXGroup;
+			children = (
+				A100000000000000000000A6 /* ChatGPTStyleChat */,
+				A100000000000000000000A3 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A100000000000000000000A3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A100000000000000000000A5 /* ChatGPTStyleChat.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A100000000000000000000A4 /* ChatGPTStyleChat */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A100000000000000000000B2 /* Build configuration list for PBXNativeTarget "ChatGPTStyleChat" */;
+			buildPhases = (
+				A100000000000000000000A7 /* Sources */,
+				A100000000000000000000A8 /* Frameworks */,
+				A100000000000000000000A9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A100000000000000000000A6 /* ChatGPTStyleChat */,
+			);
+			name = ChatGPTStyleChat;
+			packageProductDependencies = (
+				A100000000000000000000B8 /* AgentSquad */,
+			);
+			productName = ChatGPTStyleChat;
+			productReference = A100000000000000000000A5 /* ChatGPTStyleChat.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A100000000000000000000A1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2600;
+				LastUpgradeCheck = 2600;
+				TargetAttributes = {
+					A100000000000000000000A4 = {
+						CreatedOnToolsVersion = 26.0;
+					};
+				};
+			};
+			buildConfigurationList = A100000000000000000000B1 /* Build configuration list for PBXProject "ChatGPTStyleChat" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A100000000000000000000A2;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				A100000000000000000000B7 /* XCLocalSwiftPackageReference "../../.." */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A100000000000000000000A3 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A100000000000000000000A4 /* ChatGPTStyleChat */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A100000000000000000000A9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A100000000000000000000A7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A100000000000000000000B3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A100000000000000000000B4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A100000000000000000000B5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.ChatGPTStyleChat;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A100000000000000000000B6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.ChatGPTStyleChat;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A100000000000000000000B1 /* Build configuration list for PBXProject "ChatGPTStyleChat" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000000000000000000B3 /* Debug */,
+				A100000000000000000000B4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A100000000000000000000B2 /* Build configuration list for PBXNativeTarget "ChatGPTStyleChat" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000000000000000000B5 /* Debug */,
+				A100000000000000000000B6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		A100000000000000000000B7 /* XCLocalSwiftPackageReference "../../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A100000000000000000000B8 /* AgentSquad */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AgentSquad;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A100000000000000000000A1 /* Project object */;
+}

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat.xcodeproj/xcshareddata/xcschemes/ChatGPTStyleChat.xcscheme
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat.xcodeproj/xcshareddata/xcschemes/ChatGPTStyleChat.xcscheme
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A100000000000000000000A4"
+               BuildableName = "ChatGPTStyleChat.app"
+               BlueprintName = "ChatGPTStyleChat"
+               ReferencedContainer = "container:ChatGPTStyleChat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A100000000000000000000A4"
+            BuildableName = "ChatGPTStyleChat.app"
+            BlueprintName = "ChatGPTStyleChat"
+            ReferencedContainer = "container:ChatGPTStyleChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A100000000000000000000A4"
+            BuildableName = "ChatGPTStyleChat.app"
+            BlueprintName = "ChatGPTStyleChat"
+            ReferencedContainer = "container:ChatGPTStyleChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ChatGPTStyleChatApp.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ChatGPTStyleChatApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct ChatGPTStyleChatApp: App {
+    @StateObject private var vm = ChatViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ChatView(vm: vm)
+        }
+    }
+}

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ChatView.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ChatView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct ChatView: View {
+    @ObservedObject var vm: ChatViewModel
+    @State private var draft = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            messages
+            Divider()
+            composer
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Shop").font(.headline)
+            Spacer()
+            Text(vm.showWidgets ? "Text + widgets" : "Text only")
+                .font(.caption).foregroundStyle(.secondary)
+            Toggle("Widgets", isOn: $vm.showWidgets).labelsHidden()
+        }
+        .padding()
+    }
+
+    private var messages: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(vm.items) { item in
+                    VStack(alignment: item.isUser ? .trailing : .leading, spacing: 8) {
+                        if let payload = item.widget {
+                            WidgetHostView(payload: payload) { tool, args in
+                                vm.handleWidgetTool(tool, arguments: args, for: item.id)
+                            }
+                            .frame(height: 200)
+                            .clipShape(RoundedRectangle(cornerRadius: 14))
+                        }
+                        if !item.text.isEmpty {
+                            Text(item.text)
+                                .padding(10)
+                                .background(item.isUser ? Color.blue.opacity(0.15)
+                                                        : Color.gray.opacity(0.12))
+                                .clipShape(RoundedRectangle(cornerRadius: 14))
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: item.isUser ? .trailing : .leading)
+                }
+            }
+            .padding()
+        }
+    }
+
+    private var composer: some View {
+        HStack {
+            TextField("Try: where is my order #1234?", text: $draft)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(send)
+            Button("Send", action: send)
+        }
+        .padding()
+    }
+
+    private func send() {
+        vm.send(draft)
+        draft = ""
+    }
+}

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ChatViewModel.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ChatViewModel.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import AgentSquad
+
+struct ChatItem: Identifiable {
+    let id = UUID()
+    var text: String = ""
+    var widget: UIPayload? = nil
+    let isUser: Bool
+}
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published var items: [ChatItem] = []
+
+    /// Header toggle — flips between the two modes from the article.
+    @Published var showWidgets = true
+
+    private let withWidgets: Orchestrator    // GroundedAgent with ui: .forward
+    private let textOnly: Orchestrator       // GroundedAgent with ui: .suppress
+    private let shopProvider = ShopToolProvider()
+
+    init() {
+        let key       = Config.openAIKey
+        let brain     = ChatCompletionsClient(model: "gpt-4o", apiKey: key)       // fetches
+        let presenter = ChatCompletionsClient(model: "gpt-4o-mini", apiKey: key)  // talks
+        let provider  = shopProvider
+
+        let gathererPrompt = """
+            You are the data brain of a shopping assistant.
+            GATHER the facts needed to answer the user — never write the final reply.
+
+            Tools:
+              get_order(orderId) → order status + delivery estimate
+
+            Rules:
+            - Call whatever tools you need to answer the question.
+            - Use the chat history to resolve follow-ups.
+            - Never invent values. If a tool returns nothing, say so.
+            - Do NOT address the user or format anything — the presenter does that.
+            """
+
+        let presenterPrompt = PresenterPrompt(
+            default: "Present the data to the user. Use ONLY what's provided. Be concise and natural.",
+            perTool: [
+                "get_order": """
+                    Present an order status. State the order ID, current status, and estimated
+                    delivery in one sentence. Use only the data provided.
+                    """
+            ]
+        )
+
+        func makeAgent(ui: UIPolicy) -> GroundedAgent {
+            GroundedAgent(
+                name: "Shop",
+                description: "Product & order help, grounded in real data.",
+                gatherer: brain,
+                presenter: presenter,
+                tools: provider,
+                curator: .dataBlock,
+                gathererPrompt: gathererPrompt,
+                presenterPrompt: presenterPrompt,
+                ui: ui
+            )
+        }
+
+        // DeviceChatStorage is SwiftData (iOS 17+). Fall back to in-memory if it can't open a store
+        // (disk pressure, sandbox) — or on iOS 16, where DeviceChatStorage is unavailable.
+        let store: any ChatStorage = (try? DeviceChatStorage(userId: "u1")) ?? InMemoryChatStorage()
+        withWidgets = Orchestrator(agents: [makeAgent(ui: .forward)],  store: store)
+        textOnly    = Orchestrator(agents: [makeAgent(ui: .suppress)], store: store)
+    }
+
+    func send(_ text: String) {
+        let clean = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !clean.isEmpty else { return }
+
+        items.append(ChatItem(text: clean, isUser: true))
+        items.append(ChatItem(isUser: false))           // assistant reply, filled in as events arrive
+        let index = items.count - 1
+        let router = showWidgets ? withWidgets : textOnly
+
+        Task {
+            do {
+                for try await event in router.route(.text(clean), userId: "u1", sessionId: "s1") {
+                    switch event {
+                    case .textDelta(let token): items[index].text += token
+                    case .widget(let payload):  items[index].widget = payload
+                    case .error(let message):   items[index].text += "\n⚠️ \(message)"
+                    default: break
+                    }
+                }
+            } catch {
+                items[index].text += "\n⚠️ \(error.localizedDescription)"
+            }
+        }
+    }
+
+    /// Called when a rendered widget invokes an `.app`-only tool (e.g. the Refresh button).
+    /// We call the provider directly — the model is never involved — and push the fresh `UIPayload`
+    /// back into the same chat item, which re-hydrates the widget in place.
+    func handleWidgetTool(_ name: String, arguments: JSONValue, for itemID: UUID) {
+        Task {
+            guard let index = items.firstIndex(where: { $0.id == itemID }) else { return }
+            if let payload = try? await shopProvider.call(name, arguments: arguments).ui {
+                items[index].widget = payload
+            }
+        }
+    }
+}

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/Config.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/Config.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum Config {
+    /// Set `OPENAI_API_KEY` in your scheme's environment variables, or paste a key below for a quick
+    /// local test. Do NOT commit a real key.
+    static let openAIKey: String = {
+        if let env = ProcessInfo.processInfo.environment["OPENAI_API_KEY"], !env.isEmpty {
+            return env
+        }
+        return "PASTE_YOUR_OPENAI_KEY_HERE"
+    }()
+}

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/OrderCard.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/OrderCard.swift
@@ -1,0 +1,40 @@
+enum OrderCard {
+    /// The widget template (`ui://shop/order-card`). It reads `window.WIDGET_DATA` — the render-only
+    /// `structuredContent` injected by the host — and exposes `window.render()` so the host can push
+    /// fresh data after an `.app`-only tool call (Refresh).
+    static let html = """
+    <!-- ui://shop/order-card -->
+    <style>
+      body { margin: 0; background: transparent; }
+      .card { font-family: -apple-system, system-ui; border-radius: 14px; padding: 16px;
+              background: #fff; box-shadow: 0 1px 4px rgba(0,0,0,.12); }
+      h3 { margin: 0 0 8px; }
+      .status { color: #0a7; font-weight: 600; margin: 4px 0; }
+      button { margin-top: 12px; border: 0; border-radius: 8px; padding: 8px 14px;
+               background: #0a7; color: #fff; font-weight: 600; }
+    </style>
+    <div class="card">
+      <h3>Order <span id="id"></span></h3>
+      <p class="status" id="status"></p>
+      <p>ETA <strong id="eta"></strong> · <span id="carrier"></span></p>
+      <button onclick="refresh()">Refresh</button>
+    </div>
+    <script>
+      function render() {
+        const d = window.WIDGET_DATA || {};
+        document.getElementById('id').textContent      = d.orderId || '';
+        document.getElementById('status').textContent  = d.status  || '';
+        document.getElementById('eta').textContent     = d.eta     || '';
+        document.getElementById('carrier').textContent = d.carrier || '';
+      }
+      function refresh() {
+        window.webkit.messageHandlers.host.postMessage(JSON.stringify({
+          tool: 'refresh_order',
+          args: { orderId: (window.WIDGET_DATA || {}).orderId }
+        }));
+      }
+      window.render = render;   // host calls this again after pushing fresh data
+      render();                 // initial paint from data injected at document start
+    </script>
+    """
+}

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ShopToolProvider.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ShopToolProvider.swift
@@ -1,0 +1,90 @@
+import AgentSquad
+import Foundation
+
+/// A native Swift tool provider — no backend required.
+///
+/// `get_order`     is callable by the model AND advertises a widget (`ui:`).
+/// `refresh_order` is `.app`-only: only the rendered widget can call it, never the LLM.
+struct ShopToolProvider: ToolProvider {
+
+    static let orderCardURI = "ui://shop/order-card"
+
+    /// Every tool this provider can run. `listTools()` advertises only the model-visible ones;
+    /// `.app`-only tools stay callable via `call(_:arguments:)` but are never shown to the LLM.
+    private let allTools: [AgentTool] = [
+        AgentTool(
+            name: "get_order",
+            description: "Look up an order's status and delivery estimate.",
+            inputSchema: [
+                "type": "object",
+                "properties": ["orderId": ["type": "string", "description": "The order ID"]],
+                "required": ["orderId"]
+            ],
+            ui: Self.orderCardURI
+        ),
+        AgentTool(
+            name: "refresh_order",
+            description: "Refresh the order card with the latest status.",
+            inputSchema: [
+                "type": "object",
+                "properties": ["orderId": ["type": "string"]],
+                "required": ["orderId"]
+            ],
+            ui: Self.orderCardURI,
+            visibility: .app          // widget-only; never offered to the model
+        )
+    ]
+
+    /// Model-visible tools only — mirrors what the built-in `ToolKit` does internally. A custom
+    /// provider must filter here itself, or an `.app` tool would still be advertised to the LLM.
+    func listTools() async throws -> [AgentTool] {
+        allTools.filter { $0.visibility.contains(.model) }
+    }
+
+    func call(_ name: String, arguments: JSONValue) async throws -> ToolResult {
+        switch name {
+        case "get_order", "refresh_order":
+            guard case .string(let orderId)? = arguments["orderId"] else {
+                return .failure("Missing required argument: orderId")
+            }
+            return order(orderId, refreshed: name == "refresh_order")
+        default:
+            return .failure("Unknown tool: \(name)")
+        }
+    }
+
+    // MARK: - Faked backend (replace with your API / database)
+
+    private func order(_ orderId: String, refreshed: Bool) -> ToolResult {
+        let status  = refreshed ? "Out for delivery" : "In transit"
+        let eta     = refreshed ? "Today, 6:00 PM"   : "2026-07-02"
+        let carrier = "FastShip"
+
+        // Single source of truth — both the text and the widget render from this.
+        let data: JSONValue = [
+            "orderId": .string(orderId),
+            "status":  .string(status),
+            "eta":     .string(eta),
+            "carrier": .string(carrier),
+            "items":   ["Wireless Headphones", "USB-C Cable"]
+        ]
+
+        return ToolResult(
+            // text → the Brain's context (so it can reason / follow up)
+            content: [.text("Order \(orderId): \(status), ETA \(eta) via \(carrier).")],
+            // structured data → not added to the model's context; hydrates the curator + widget
+            structuredContent: data,
+            // the self-contained widget package
+            ui: UIPayload(
+                resourceURI: Self.orderCardURI,
+                mimeType: "text/html;profile=mcp-app",
+                template: .html(OrderCard.html),
+                structuredContent: data,
+                security: UISecurity(
+                    resourceDomains: ["https://cdn.myshop.com"],  // images allowed from here
+                    prefersBorder: true
+                )
+            )
+        )
+    }
+}

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/WidgetHostView.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/WidgetHostView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+import WebKit
+import AgentSquad
+
+/// Renders a `UIPayload` HTML template inside a locked-down `WKWebView`:
+///  • injects `structuredContent` as `window.WIDGET_DATA` (render-only — the model never sees it)
+///  • enforces the payload's `UISecurity` as a Content-Security-Policy
+///  • bridges widget → app so `.app`-only tools (Refresh) can call back into Swift
+struct WidgetHostView: UIViewRepresentable {
+    let payload: UIPayload
+    let onAppTool: @MainActor (String, JSONValue) -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(onAppTool: onAppTool) }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let controller = WKUserContentController()
+        controller.add(context.coordinator, name: "host")
+
+        // Inject the render-only data BEFORE any page script runs.
+        controller.addUserScript(
+            WKUserScript(source: "window.WIDGET_DATA = \(jsonString(payload.structuredContent));",
+                         injectionTime: .atDocumentStart,
+                         forMainFrameOnly: true)
+        )
+
+        let config = WKWebViewConfiguration()
+        config.userContentController = controller
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.scrollView.isScrollEnabled = false
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+
+        if case .html(let html)? = payload.template {
+            webView.loadHTMLString(cspMeta(payload.security) + html, baseURL: nil)
+        }
+        context.coordinator.lastData = jsonString(payload.structuredContent)
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        // If the payload's data changed (e.g. after Refresh), push it and re-render.
+        let current = jsonString(payload.structuredContent)
+        guard current != context.coordinator.lastData else { return }
+        context.coordinator.lastData = current
+        webView.evaluateJavaScript("window.WIDGET_DATA = \(current); window.render && window.render();")
+    }
+
+    static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "host")
+    }
+
+    // MARK: - Helpers
+
+    private func jsonString(_ value: JSONValue) -> String {
+        guard let data = try? JSONEncoder().encode(value),
+              let string = String(data: data, encoding: .utf8) else { return "{}" }
+        return string
+    }
+
+    /// Build a `<meta>` CSP from `UISecurity`. Undeclared domains are blocked.
+    private func cspMeta(_ security: UISecurity?) -> String {
+        let s = security ?? UISecurity()
+        let connect = (["'self'"] + s.connectDomains).joined(separator: " ")
+        let img     = (["'self'", "data:"] + s.resourceDomains).joined(separator: " ")
+        let frame   = (["'none'"] + s.frameDomains).joined(separator: " ")
+        return """
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; \
+        style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src \(img); \
+        connect-src \(connect); frame-src \(frame);">
+        """
+    }
+
+    final class Coordinator: NSObject, WKScriptMessageHandler {
+        let onAppTool: @MainActor (String, JSONValue) -> Void
+        var lastData = ""
+
+        init(onAppTool: @escaping @MainActor (String, JSONValue) -> Void) {
+            self.onAppTool = onAppTool
+        }
+
+        func userContentController(_ uc: WKUserContentController,
+                                   didReceive message: WKScriptMessage) {
+            // WebKit delivers script messages on the main thread.
+            guard let body = message.body as? String,
+                  let data = body.data(using: .utf8),
+                  let call = try? JSONDecoder().decode(AppToolCall.self, from: data) else { return }
+            MainActor.assumeIsolated {
+                onAppTool(call.tool, call.args ?? .object([:]))
+            }
+        }
+    }
+
+    private struct AppToolCall: Decodable {
+        let tool: String
+        let args: JSONValue?
+    }
+}

--- a/examples/swift/ChatGPTStyleChat/README.md
+++ b/examples/swift/ChatGPTStyleChat/README.md
@@ -1,0 +1,72 @@
+# Chatbots, Meet Your UI — sample app
+
+The complete, runnable companion to the article **"Chatbots, Meet Your UI: Building ChatGPT-Style
+Chat Apps on iOS."**
+
+A native SwiftUI chat that answers in **text *and* interactive widgets**, built on the
+[Agent Squad](https://github.com/2FastLabs/agent-squad) Swift framework. The assistant uses a
+**GroundedAgent** (a *Brain* that fetches via tools + a *Presenter* that speaks only from those
+facts), and a tool that returns a `UIPayload` widget rendered natively in a locked-down `WKWebView`.
+
+What this sample gives you on top of the article's snippets:
+
+- The full **wiring** (`@main` App → `ChatViewModel` → `Orchestrator` → `GroundedAgent` → `ShopToolProvider`).
+- A **Widgets on/off toggle** in the header — the same agent in `ui: .forward` vs `ui: .suppress`,
+  so you can see *text + widget* vs *text only* side by side.
+- The complete **Refresh round-trip**: the card's button calls an `.app`-only tool (invisible to the
+  LLM), the host pushes fresh data back into the same `WKWebView`, and the widget re-hydrates.
+
+## Requirements
+
+- Xcode 26+ with the **Swift 6.2** toolchain
+- iOS 17+ simulator or device (the sample uses `DeviceChatStorage`, which is SwiftData; for iOS 16
+  swap it for `InMemoryChatStorage()` — see `ChatViewModel.swift`)
+- An OpenAI API key (or any OpenAI-compatible endpoint)
+
+## Run it (2 minutes)
+
+This project is ready to open — no setup, no `Add Package` step. It references the Agent Squad
+package by **local path** (`../../..`, the repo root), so it always builds against the checked-out
+framework.
+
+1. `open examples/swift/ChatGPTStyleChat/ChatGPTStyleChat.xcodeproj`
+2. **Set your key**: either add `OPENAI_API_KEY` to the scheme's *Run → Environment Variables*, or
+   paste it into `Config.swift`. **Don't commit a real key.**
+3. Pick an **iOS 17+ simulator** and hit **Run**.
+4. Try: `where is my order #1234?`
+
+> Using this outside the repo? Delete the local package reference and add the remote one instead —
+> *File → Add Package Dependencies…* → `https://github.com/2FastLabs/agent-squad`, branch `main`,
+> product **AgentSquad**.
+
+## Try this
+
+- Ask **"where is my order #1234?"** → an order card appears, with a grounded sentence underneath.
+- Tap **Refresh** on the card → the status flips to *Out for delivery* with a new ETA. Notice the LLM
+  was never involved — the widget called the `.app`-only `refresh_order` tool directly.
+- Flip the **Widgets** toggle off and ask again → the *same* grounded answer, as text only.
+
+## How it maps to the article
+
+| File | Article section |
+|------|-----------------|
+| `ChatGPTStyleChatApp.swift` | the `@main` entry point |
+| `Config.swift` | the API key plumbing (Prerequisites) |
+| `ShopToolProvider.swift` | **Step 3** — a tool that returns a widget (`get_order`) + an `.app`-only tool (`refresh_order`) |
+| `OrderCard.swift` | **Step 6** — the `orderCardHTML` template |
+| `ChatViewModel.swift` | **Step 2 & 4** — the GroundedAgent, prompts, and the `.forward`/`.suppress` toggle; the widget→app callback |
+| `ChatView.swift` | **Step 5** — the SwiftUI chat |
+| `WidgetHostView.swift` | **Step 6** — the `WKWebView` host: data injection, CSP from `UISecurity`, and the postMessage bridge |
+
+## Notes
+
+- The "backend" in `ShopToolProvider` is faked in-memory so the sample runs with zero infrastructure.
+  Replace `order(_:refreshed:)` with your real API/database call.
+- **Tool visibility is enforced by the provider.** `ShopToolProvider.listTools()` filters to
+  model-visible tools (`visibility.contains(.model)`), so the `.app`-only `refresh_order` is never
+  advertised to the LLM — it stays callable directly via `call(_:arguments:)`. The built-in `ToolKit`
+  does this filtering for you; a custom provider must do it itself.
+- `structuredContent` hydrates the widget and is not added to the model's context (the model reasons
+  from the tool's `content` text), so the card can't be hallucinated from.
+- The whole thing runs **on device**. Point `ChatCompletionsClient` at a local model and you get
+  offline, "free-token" inference (see `ChatViewModel.swift`).


### PR DESCRIPTION
## Issue Link

Closes #588

## Summary

Adds a small, runnable SwiftUI iOS sample under `examples/swift/ChatGPTStyleChat` that shows the GroundedAgent + tool-UI flow end to end — the companion to the "Chatbots, Meet Your UI" article. It opens in Xcode and runs with just an OpenAI key; it references the package by local path (`../../..`), so it always builds against the checked-out framework.

## Changes

- New example app: `@main` App → `ChatViewModel` → `Orchestrator` → `GroundedAgent` → `ShopToolProvider`.
- `GroundedAgent` with a gatherer brain (`gpt-4o`) and a cheaper presenter (`gpt-4o-mini`), grounded in tool data via `PresenterPrompt` per-tool prompts.
- Native `ToolProvider` whose `get_order` tool returns a `UIPayload` widget; `structuredContent` is render-only.
- `WidgetHostView` renders the widget in a locked-down `WKWebView`: injects data at document start, builds a CSP from `UISecurity`, bridges widget→app, removes the handler in `dismantleUIView`.
- `.app`-only tool visibility: `listTools()` filters to `visibility.contains(.model)` (mirrors `ToolKit`), so `refresh_order` is never advertised to the LLM but stays callable — powering the Refresh round-trip.
- Widgets on/off toggle demonstrating `ui: .forward` vs `.suppress`.
- Committed `.xcodeproj` + shared scheme; `.gitignore` excludes user state and the resolved-package workspace.

## User experience

`open examples/swift/ChatGPTStyleChat/ChatGPTStyleChat.xcodeproj`, set `OPENAI_API_KEY`, pick an iOS 17+ simulator, Run. Ask "where is my order #1234?" → an order card renders with a grounded sentence; tap Refresh → the card updates without involving the LLM; flip the Widgets toggle → the same grounded answer as text only.

## Checklist

- [x] Example builds for the iOS Simulator (`xcodebuild`, Swift 6 language mode)
- [x] Uses only public AgentSquad API, verified against source
- [x] No framework code changed; purely additive under `examples/`
- [x] README documents setup, the article mapping, and the local→remote package switch

Code written by Claude (Opus 4.8), architected and approved by @cornelcroi.