### PR TITLE
feat(python): add tool-UI (widget) support to GroundedAgent

### DIFF
--- a/docs/src/content/docs/agents/built-in/grounded-agent.mdx
+++ b/docs/src/content/docs/agents/built-in/grounded-agent.mdx
@@ -8,7 +8,7 @@ The `GroundedAgent` is the framework's answer to LLM hallucination in tool-drive
 A chit-chat turn that calls no tools skips the presenter entirely: the gatherer answers directly in one pass.
 
 :::note
-This mirrors the Swift [`GroundedAgent`](/agent-squad/swift/agents/built-in/grounded-agent/). The Swift variant additionally supports tool-UI widgets (`UIPolicy`) and per-phase trace spans; those have no equivalent in the Python/TypeScript trees and are intentionally omitted here.
+Tool-UI widgets are supported in Swift and Python — a tool can return a component that the `GroundedAgent` forwards to the caller (see [Tool UI](#tool-ui-widgets) below). TypeScript support is not yet available. Per-phase trace spans remain Swift-only.
 :::
 
 ## How it works
@@ -385,6 +385,65 @@ When the gatherer makes no tool calls, the `GroundedAgent` emits the gatherer's 
 ## Streaming
 
 `GroundedAgent` streams when its **presenter** streams (`is_streaming_enabled` / `isStreamingEnabled` tracks the presenter). On a no-tool turn the gatherer's reply is re-emitted as a single streamed chunk. The gatherer always runs to completion internally so its tool results can be captured before the presenter is invoked.
+
+## Tool UI (widgets)
+
+<span id="tool-ui-widgets"></span>
+
+*Python only for now; TypeScript support is not yet available.*
+
+A tool can return an interactive UI component (an "MCP App" widget) alongside its text. Instead of a plain string, the tool returns a `ToolResult`:
+
+- `content` — the text added to the model's context (what the gatherer reads).
+- `structured_content` — the data the widget renders from. **Render-only**: never added to the model's context, so the model cannot hallucinate from it. The curator also feeds the presenter from this.
+- `ui` — a `UIPayload`: the self-contained component (its `resource_uri`, `mime_type`, `template`, render-only `structured_content`, and a `UISecurity` policy the host turns into a CSP).
+
+When the turn's primary tool returns a `UIPayload`, the `GroundedAgent` forwards it to the caller on the **streaming path** as the `ui` field of an `AgentStreamResponse`, emitted before the presenter's text streams in. This is governed by `ui_policy` (`UIPolicy.FORWARD`, the default, or `UIPolicy.SUPPRESS` to drop the widget and keep the grounded text only). Drawing the widget is the host's job — the framework only carries the data.
+
+```python
+from agent_squad.utils import AgentTool, AgentTools, ToolResult, UIPayload, UISecurity, UIPolicy
+from agent_squad.agents import GroundedAgent, GroundedAgentOptions
+
+def get_order(order_id: str) -> ToolResult:
+    """Look up an order's status and delivery estimate.
+
+    :param order_id: the order id
+    """
+    data = {"order_id": order_id, "status": "In transit", "eta": "2026-07-02"}
+    return ToolResult(
+        # text → the gatherer's context (so it can reason / follow up)
+        content=f"Order {order_id}: {data['status']}, ETA {data['eta']}.",
+        # render-only → hydrates the widget and the presenter feed, never the model
+        structured_content=data,
+        ui=UIPayload(
+            resource_uri="ui://shop/order-card",
+            mime_type="text/html;profile=mcp-app",
+            template="<div class='card'>…render from window.WIDGET_DATA…</div>",
+            structured_content=data,
+            security=UISecurity(resource_domains=["https://cdn.myshop.com"], prefers_border=True),
+        ),
+    )
+
+tools = AgentTools([AgentTool(name="get_order", func=get_order, required=["order_id"])])
+
+shop = GroundedAgent(GroundedAgentOptions(
+    name="Shop",
+    description="Orders, grounded in real data.",
+    gatherer=gatherer,          # built as above, with tools=tools
+    presenter=presenter,
+    tools=tools,
+    ui_policy=UIPolicy.FORWARD,  # default; use SUPPRESS for text-only
+))
+
+# Consume the widget on the stream:
+async for chunk in await shop.process_request("where is my order #1234?", user_id, session_id, []):
+    if chunk.ui is not None:
+        render_widget(chunk.ui)          # your host renders the component
+    elif chunk.text:
+        print(chunk.text, end="")        # the grounded sentence streams underneath
+```
+
+An `.app`-only tool (one the widget calls back into, but the model must never see) is kept out of what the model is offered by filtering the provider's tool list to model-visible tools — the same way the widget's Refresh button re-invokes a tool without the LLM's involvement.
 
 ## Relation to other types
 

--- a/python/src/agent_squad/agents/agent.py
+++ b/python/src/agent_squad/agents/agent.py
@@ -3,7 +3,7 @@ import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from agent_squad.types import ConversationMessage
-from agent_squad.utils import Logger
+from agent_squad.utils import Logger, UIPayload
 from uuid import UUID
 
 # Type aliases for complex types
@@ -41,12 +41,14 @@ class AgentStreamResponse:
     Attributes:
         text: The current text in the stream
         final_message: The complete message when streaming is complete
+        ui: A tool-advertised widget for this turn, when one was forwarded (render-only).
     """
 
     text: str = ""
     thinking: Optional[str] = ""
     final_message: Optional[ConversationMessage] = None
     final_thinking: Optional[str] = None
+    ui: Optional[UIPayload] = None
 
 
 @dataclass

--- a/python/src/agent_squad/agents/grounded_agent.py
+++ b/python/src/agent_squad/agents/grounded_agent.py
@@ -106,7 +106,12 @@ class Grounding:
 
     @staticmethod
     def primary(results: list[CapturedToolResult]) -> Optional[CapturedToolResult]:
-        """The turn's primary tool: the last call (drives the presenter prompt selection)."""
+        """The turn's primary tool: the last call that advertised a UI widget, else the last call.
+        Drives both the presenter prompt and the forwarded widget, so a widget still surfaces when a
+        non-UI helper runs after the UI tool."""
+        for result in reversed(results):
+            if isinstance(result.result, ToolResult) and result.result.ui is not None:
+                return result
         return results[-1] if results else None
 
     @staticmethod

--- a/python/src/agent_squad/agents/grounded_agent.py
+++ b/python/src/agent_squad/agents/grounded_agent.py
@@ -5,8 +5,8 @@ A *gatherer* LLM calls tools and sees the raw results but never speaks to the us
 so it cannot invent values beyond what was fetched. A chit-chat turn that calls no tools is answered
 in one pass by the gatherer, skipping the presenter.
 
-This mirrors the Swift ``GroundedAgent``. The tool-UI (widget) and trace-span machinery from the
-Swift implementation has no equivalent in this tree and is intentionally omitted.
+When a tool returns a ``ToolResult`` carrying a UI widget, the primary tool's widget is forwarded to
+the caller on the streaming response, governed by ``ui_policy``.
 """
 
 import json
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncIterable, Callable, Optional, Union
 
 from agent_squad.types import ConversationMessage, ParticipantRole
-from agent_squad.utils import AgentToolCallbacks, AgentTools, Logger
+from agent_squad.utils import AgentToolCallbacks, AgentTools, Logger, ToolResult, UIPayload, UIPolicy
 
 from .agent import Agent, AgentOptions, AgentStreamResponse
 
@@ -54,10 +54,14 @@ class DataBlockCurator(ToolOutputCurator):
     @staticmethod
     def section(result: CapturedToolResult) -> str:
         """One section. Also used as ``PerToolCurator``'s fallback formatter."""
-        if isinstance(result.result, str):
-            body = result.result
+        value = result.result
+        if isinstance(value, ToolResult):
+            # Curate from the render-only structured data (the facts), not the widget wrapper.
+            value = value.structured_content or value.content
+        if isinstance(value, str):
+            body = value
         else:
-            body = json.dumps(result.result, indent=2, sort_keys=True, default=str)
+            body = json.dumps(value, indent=2, sort_keys=True, default=str)
         return f"### {result.name}\n{body}"
 
 
@@ -106,6 +110,14 @@ class Grounding:
         return results[-1] if results else None
 
     @staticmethod
+    def primary_ui(results: list[CapturedToolResult]) -> Optional[UIPayload]:
+        """The widget advertised by the primary tool, if it returned one."""
+        primary = Grounding.primary(results)
+        if primary and isinstance(primary.result, ToolResult):
+            return primary.result.ui
+        return None
+
+    @staticmethod
     def presenter_message(question: str, data: str) -> str:
         """The presenter's user message: question and curated data, tagged so the model can tell
         them apart."""
@@ -150,6 +162,8 @@ class GroundedAgentOptions(AgentOptions):
         tools: The ``AgentTools`` the gatherer uses. GroundedAgent hooks it to capture results.
         curator: Shapes gathered results into the presenter feed. Default: ``DataBlockCurator``.
         presenter_prompt: Per-tool presenter system prompts. Default: a generic grounding prompt.
+        ui_policy: Whether a tool-advertised widget is forwarded to the caller (on the streaming
+            path only). Default: forward.
     """
 
     gatherer: Agent = None
@@ -157,6 +171,7 @@ class GroundedAgentOptions(AgentOptions):
     tools: AgentTools = None
     curator: ToolOutputCurator = field(default_factory=DataBlockCurator)
     presenter_prompt: PresenterPrompt = field(default_factory=PresenterPrompt.default)
+    ui_policy: UIPolicy = UIPolicy.FORWARD
 
 
 class GroundedAgent(Agent):
@@ -174,6 +189,7 @@ class GroundedAgent(Agent):
         self.tools = options.tools
         self.curator = options.curator
         self.presenter_prompt = options.presenter_prompt
+        self.ui_policy = options.ui_policy
 
     def is_streaming_enabled(self) -> bool:
         # The final reply is the presenter's, so streaming tracks the presenter (no-tool turns are
@@ -280,6 +296,11 @@ class GroundedAgent(Agent):
             message = ConversationMessage(role=ParticipantRole.ASSISTANT.value, content=[{"text": draft}])
             yield AgentStreamResponse(text=draft, final_message=message)
             return
+        # Forward the primary tool's widget (if any) before the presenter's text streams in.
+        if self.ui_policy == UIPolicy.FORWARD:
+            widget = Grounding.primary_ui(captured)
+            if widget is not None:
+                yield AgentStreamResponse(ui=widget)
         response = await self._present(
             input_text, user_id, session_id, chat_history, additional_params, captured
         )

--- a/python/src/agent_squad/utils/__init__.py
+++ b/python/src/agent_squad/utils/__init__.py
@@ -1,7 +1,8 @@
 """Module for importing helper functions and Logger."""
 from .helpers import is_tool_input, conversation_to_dict
 from .logger import Logger
-from .tool import AgentTool, AgentTools, AgentToolCallbacks
+from .tool import AgentTool, AgentTools, AgentToolCallbacks, ToolResult
+from .ui import UIPayload, UISecurity, UIPolicy
 
 __all__ = [
     'is_tool_input',
@@ -9,5 +10,9 @@ __all__ = [
     'Logger',
     'AgentTool',
     'AgentTools',
-    'AgentToolCallbacks'
+    'AgentToolCallbacks',
+    'ToolResult',
+    'UIPayload',
+    'UISecurity',
+    'UIPolicy',
 ]

--- a/python/src/agent_squad/utils/tool.py
+++ b/python/src/agent_squad/utils/tool.py
@@ -1,13 +1,15 @@
 from typing import Any, Optional, Callable, get_type_hints
 import inspect
+import json
 from functools import wraps
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from agent_squad.types import (
     AgentProviderType,
     ConversationMessage,
     ParticipantRole,
 )
+from agent_squad.utils.ui import UIPayload
 from uuid import UUID
 
 
@@ -18,6 +20,19 @@ class PropertyDefinition:
     enum: Optional[list] = None
 
 
+@dataclass
+class ToolResult:
+    """A tool return that carries render-only data and/or a UI widget. Only ``content`` (text) is
+    added to the model's context; ``structured_content`` and ``ui`` never reach the model. Tools
+    that need none of this can still just return a string."""
+
+    content: str = ""
+    structured_content: Any = field(default_factory=dict)
+    ui: Optional[UIPayload] = None
+
+
+# Internal wire wrapper (tool_use_id + text) that formats a result for the model. Not the same as
+# the public ``ToolResult`` below, which is what a tool returns.
 @dataclass
 class AgentToolResult:
     tool_use_id: str
@@ -270,8 +285,14 @@ class AgentTools:
                 tool_name, input_data, result, metadata={"agent_info": agent_info}
             )
 
-            # Create tool result
-            tool_result = AgentToolResult(tool_id, result)
+            # A ToolResult carries render-only data/UI; only its text goes to the model. Empty text
+            # falls back to the structured data so the model isn't blind. Plain returns pass through.
+            if isinstance(result, ToolResult):
+                model_content = result.content or json.dumps(result.structured_content, default=str)
+            else:
+                model_content = result
+
+            tool_result = AgentToolResult(tool_id, model_content)
 
             # Format according to platform
             formatted_result = (

--- a/python/src/agent_squad/utils/ui.py
+++ b/python/src/agent_squad/utils/ui.py
@@ -1,0 +1,48 @@
+"""Tool-UI (widget) types.
+
+A tool can return a self-contained UI component (an "MCP App" widget) alongside its text. The host
+renders it from ``structured_content``, which is render-only: never added to the model's context, so
+the model cannot hallucinate from it. These types carry the data only — drawing the widget is the
+host's job.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+@dataclass
+class UISecurity:
+    """Security the host enforces when rendering a component (built into a CSP). Undeclared domains
+    are blocked."""
+
+    connect_domains: list[str] = field(default_factory=list)
+    resource_domains: list[str] = field(default_factory=list)
+    frame_domains: list[str] = field(default_factory=list)
+    permissions: list[str] = field(default_factory=list)  # e.g. "camera", "microphone"
+    domain: Optional[str] = None                          # dedicated sandbox origin
+    prefers_border: bool = False
+
+
+@dataclass
+class UIPayload:
+    """A widget package advertised by a tool. ``structured_content``/``meta`` are render-only —
+    never added to the model's context.
+
+    ``template`` is the component body (HTML, a URL, or a remote-DOM script); the kind is given by
+    ``mime_type``.
+    """
+
+    resource_uri: str                                     # e.g. "ui://shop/order-card"
+    mime_type: str                                        # e.g. "text/html;profile=mcp-app"
+    template: Optional[str] = None
+    structured_content: Any = field(default_factory=dict)
+    meta: Optional[dict[str, Any]] = None
+    security: Optional[UISecurity] = None
+
+
+class UIPolicy(str, Enum):
+    """Whether an advertised tool UI is surfaced to the caller (decided per agent)."""
+
+    FORWARD = "forward"    # surface the widget on the response (default)
+    SUPPRESS = "suppress"  # fold the data into the text answer; emit no widget

--- a/python/src/tests/agents/test_grounded_agent.py
+++ b/python/src/tests/agents/test_grounded_agent.py
@@ -15,7 +15,7 @@ from agent_squad.agents import (
 )
 from agent_squad.agents.grounded_agent import Grounding, DEFAULT_PRESENTER_PROMPT
 from agent_squad.types import ConversationMessage, ParticipantRole
-from agent_squad.utils import AgentTool, AgentTools
+from agent_squad.utils import AgentTool, AgentTools, ToolResult, UIPayload, UIPolicy
 
 
 def _msg(text: str) -> ConversationMessage:
@@ -212,6 +212,70 @@ async def test_streaming_no_tool_turn_yields_gatherer_draft():
 
 
 # ---------------------------------------------------------------------------
+# Tool UI (widget) forwarding
+# ---------------------------------------------------------------------------
+
+def _ui_tool_result():
+    payload = UIPayload(resource_uri="ui://shop/order-card", mime_type="text/html;profile=mcp-app",
+                        template="<div>card</div>", structured_content={"status": "shipped"})
+    return ToolResult(content="Order: shipped", structured_content={"status": "shipped"}, ui=payload)
+
+
+@pytest.mark.asyncio
+async def test_streaming_forwards_widget_before_presenter_text():
+    tools = _tools()
+    gatherer = _FakeGatherer(AgentOptions(name="g", description=""), tools=tools,
+                             tool_calls=[("get_order", {}, _ui_tool_result())], draft="", streaming=True)
+    presenter = _FakePresenter(AgentOptions(name="p", description=""), reply="Your order shipped.", streaming=True)
+    agent = _build(gatherer, presenter, tools)
+
+    chunks = [c async for c in await agent.process_request("order?", "u", "s", [])]
+    widget_chunks = [c for c in chunks if c.ui is not None]
+    assert len(widget_chunks) == 1
+    assert widget_chunks[0].ui.resource_uri == "ui://shop/order-card"
+    # The widget precedes the presenter's final text.
+    assert chunks.index(widget_chunks[0]) < len(chunks) - 1
+    assert chunks[-1].final_message.content[0]["text"] == "Your order shipped."
+    # The presenter is fed the structured facts, not the widget wrapper.
+    assert '"status": "shipped"' in presenter.received_input
+
+
+@pytest.mark.asyncio
+async def test_ui_policy_suppress_emits_no_widget():
+    tools = _tools()
+    gatherer = _FakeGatherer(AgentOptions(name="g", description=""), tools=tools,
+                             tool_calls=[("get_order", {}, _ui_tool_result())], draft="", streaming=True)
+    presenter = _FakePresenter(AgentOptions(name="p", description=""), reply="text only", streaming=True)
+    agent = _build(gatherer, presenter, tools, ui_policy=UIPolicy.SUPPRESS)
+
+    chunks = [c async for c in await agent.process_request("q", "u", "s", [])]
+    assert all(c.ui is None for c in chunks)
+    assert chunks[-1].final_message.content[0]["text"] == "text only"
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_collect_drops_widget():
+    # The widget is surfaced on the streaming path only; non-streaming returns a plain message.
+    tools = _tools()
+    gatherer = _FakeGatherer(AgentOptions(name="g", description=""), tools=tools,
+                             tool_calls=[("get_order", {}, _ui_tool_result())], draft="")
+    presenter = _FakePresenter(AgentOptions(name="p", description=""), reply="Your order shipped.")
+    agent = _build(gatherer, presenter, tools)
+
+    result = await agent.process_request("order?", "u", "s", [])
+    assert isinstance(result, ConversationMessage)
+    assert result.content[0]["text"] == "Your order shipped."
+
+
+def test_grounding_primary_ui():
+    tr = _ui_tool_result()
+    assert Grounding.primary_ui([CapturedToolResult("get_order", tr)]).resource_uri == "ui://shop/order-card"
+    # A plain (non-UI) primary tool yields no widget; last call wins.
+    assert Grounding.primary_ui([CapturedToolResult("a", tr), CapturedToolResult("b", "plain")]) is None
+    assert Grounding.primary_ui([]) is None
+
+
+# ---------------------------------------------------------------------------
 # Curators
 # ---------------------------------------------------------------------------
 
@@ -225,6 +289,19 @@ def test_datablock_curator_string_and_structured():
     assert "### detail\n" in out
     assert '"name": "shoe"' in out  # pretty JSON, sorted keys
     assert "\n\n" in out  # sections joined by blank line
+
+
+def test_datablock_curator_unwraps_toolresult():
+    curator = DataBlockCurator()
+    # structured_content present -> curate from it, not the widget wrapper or content text
+    out = curator.curate([CapturedToolResult("get_product", ToolResult(
+        content="ignored text", structured_content={"price": 90}))])
+    assert "### get_product" in out
+    assert '"price": 90' in out
+    assert "ignored text" not in out
+    # no structured_content -> fall back to the content text
+    out2 = curator.curate([CapturedToolResult("t", ToolResult(content="plain text"))])
+    assert "### t\nplain text" in out2
 
 
 def test_per_tool_curator_routes_and_falls_back():

--- a/python/src/tests/agents/test_grounded_agent.py
+++ b/python/src/tests/agents/test_grounded_agent.py
@@ -270,9 +270,31 @@ async def test_non_streaming_collect_drops_widget():
 def test_grounding_primary_ui():
     tr = _ui_tool_result()
     assert Grounding.primary_ui([CapturedToolResult("get_order", tr)]).resource_uri == "ui://shop/order-card"
-    # A plain (non-UI) primary tool yields no widget; last call wins.
-    assert Grounding.primary_ui([CapturedToolResult("a", tr), CapturedToolResult("b", "plain")]) is None
+    # A trailing non-UI tool must not hide an earlier widget (prefers the last UI call; Swift parity).
+    assert Grounding.primary_ui(
+        [CapturedToolResult("get_order", tr), CapturedToolResult("check_stock", "in stock")]
+    ).resource_uri == "ui://shop/order-card"
+    # No UI tool at all → no widget.
+    assert Grounding.primary_ui([CapturedToolResult("a", "plain"), CapturedToolResult("b", "plain")]) is None
     assert Grounding.primary_ui([]) is None
+
+
+@pytest.mark.asyncio
+async def test_widget_and_prompt_survive_a_trailing_non_ui_tool():
+    tools = _tools()
+    gatherer = _FakeGatherer(AgentOptions(name="g", description=""), tools=tools,
+                             tool_calls=[("get_order", {}, _ui_tool_result()),
+                                         ("check_stock", {}, "in stock")],
+                             draft="", streaming=True)
+    presenter = _FakePresenter(AgentOptions(name="p", description=""), reply="done", streaming=True)
+    prompt = PresenterPrompt(default="DEFAULT", per_tool={"get_order": "ORDER PROMPT"})
+    agent = _build(gatherer, presenter, tools, presenter_prompt=prompt)
+
+    chunks = [c async for c in await agent.process_request("q", "u", "s", [])]
+    widget_chunks = [c for c in chunks if c.ui is not None]
+    assert len(widget_chunks) == 1  # widget not dropped by the trailing non-UI tool
+    assert widget_chunks[0].ui.resource_uri == "ui://shop/order-card"
+    assert presenter.system_prompt == "ORDER PROMPT"  # prompt keyed off the UI tool
 
 
 # ---------------------------------------------------------------------------

--- a/python/src/tests/utils/test_tool.py
+++ b/python/src/tests/utils/test_tool.py
@@ -1,5 +1,5 @@
 import pytest
-from agent_squad.utils import AgentTools, AgentTool
+from agent_squad.utils import AgentTools, AgentTool, AgentToolCallbacks, ToolResult, UIPayload
 from agent_squad.types import AgentProviderType, ConversationMessage, ParticipantRole
 from anthropic import Anthropic
 from anthropic.types import ToolUseBlock
@@ -532,6 +532,61 @@ def test_self_param():
         name="test",
         func=_handler
     )])
+
+
+@pytest.mark.asyncio
+async def test_tool_handler_routes_toolresult_content_to_model():
+    """A tool returning a ToolResult: only its text reaches the model; callbacks get the full
+    object (structured data + widget), which is what GroundedAgent captures."""
+    def order_tool(order_id: str):
+        return ToolResult(
+            content=f"Order {order_id}: shipped",
+            structured_content={"order_id": order_id, "status": "shipped"},
+            ui=UIPayload(resource_uri="ui://order", mime_type="text/html;profile=mcp-app"),
+        )
+
+    captured = {}
+
+    class _CB(AgentToolCallbacks):
+        async def on_tool_end(self, tool_name, payload_input, output, *a, **k):
+            captured["output"] = output
+
+    tools = AgentTools([AgentTool(name="get_order", func=order_tool)], callbacks=_CB())
+    msg = ConversationMessage(role=ParticipantRole.ASSISTANT.value, content=[{
+        "toolUse": {"name": "get_order", "toolUseId": "1", "input": {"order_id": "42"}}}])
+
+    response = await tools.tool_handler(AgentProviderType.BEDROCK.value, msg, [])
+    # Only the text content reaches the model — not the structured data or the widget.
+    assert response.content[0]["toolResult"]["content"] == [{"text": "Order 42: shipped"}]
+    # Callbacks receive the full ToolResult (widget included).
+    assert isinstance(captured["output"], ToolResult)
+    assert captured["output"].ui.resource_uri == "ui://order"
+
+
+@pytest.mark.asyncio
+async def test_tool_handler_toolresult_empty_content_falls_back_to_structured():
+    """A ToolResult with no text: the model gets the JSON of structured_content, not a blank."""
+    def t(x: str):
+        return ToolResult(content="", structured_content={"x": x})
+
+    tools = AgentTools([AgentTool(name="t", func=t)])
+    msg = ConversationMessage(role=ParticipantRole.ASSISTANT.value, content=[{
+        "toolUse": {"name": "t", "toolUseId": "1", "input": {"x": "hi"}}}])
+    response = await tools.tool_handler(AgentProviderType.BEDROCK.value, msg, [])
+    assert response.content[0]["toolResult"]["content"] == [{"text": '{"x": "hi"}'}]
+
+
+@pytest.mark.asyncio
+async def test_tool_handler_toolresult_anthropic():
+    """The ToolResult routing applies on the Anthropic provider too."""
+    def order_tool(order_id: str):
+        return ToolResult(content=f"Order {order_id}", structured_content={"id": order_id})
+
+    tools = AgentTools([AgentTool(name="get_order", func=order_tool)])
+    msg = ConversationMessage(role=ParticipantRole.ASSISTANT.value, content=[
+        ToolUseBlock(name="get_order", type="tool_use", id="9", input={"order_id": "7"})])
+    response = await tools.tool_handler(AgentProviderType.ANTHROPIC.value, msg, [])
+    assert response.get("content")[0] == {"type": "tool_result", "tool_use_id": "9", "content": "Order 7"}
 
 
 


### PR DESCRIPTION
## Issue Link

Closes #590

## Summary

Brings the Swift `GroundedAgent`'s tool-UI (widget) capability to the Python tree: a tool can return a widget that the `GroundedAgent` forwards to the caller alongside the grounded text. Additive and fully backward compatible — string-returning tools and existing stream consumers are unchanged.

## Changes

- New `UIPayload` / `UISecurity` / `UIPolicy` in `agent_squad.utils.ui`.
- New `ToolResult(content, structured_content, ui)` a tool may return instead of a string. Only `content` is added to the model's context; `structured_content` and `ui` are render-only (never sent to the model). Empty `content` falls back to the structured JSON so the model isn't blind.
- `AgentTools.tool_handler` routes a `ToolResult`: text to the model, full object to callbacks (so `GroundedAgent` captures it). Plain returns pass through the identical path.
- `AgentStreamResponse.ui` (new optional field).
- `GroundedAgent`: `ui_policy` (`UIPolicy.FORWARD` default / `SUPPRESS`); forwards the primary tool's `UIPayload` on the streaming response before the presenter's text; the curator feeds the presenter from `structured_content`.
- Docs page updated with a Tool-UI section + Python example.

## User experience

A tool returns `ToolResult(content=..., structured_content=..., ui=UIPayload(...))`. On the streaming path, the caller receives one `AgentStreamResponse` whose `.ui` carries the widget (before the grounded text streams), and renders it — the same pattern the Swift package uses on iOS, now for web via Python.

## Checklist

- [x] Backward compatible — new field appended last with a default; `ToolResult` opt-in; existing tools/streams unchanged
- [x] Lightweight / additive — no new dependencies
- [x] Tests added (tool-loop routing + GroundedAgent widget forward/suppress + curator); 36 pass, ruff clean
- [x] Docs updated with a working example
- [ ] TypeScript parity — follow-up PR

Note: MCP-provider UI passthrough and the non-streaming widget surface are deliberate follow-ups (native-tool + streaming path lands here).

Code written by Claude (Opus 4.8), architected and approved by @cornelcroi.