### PR TITLE
feat(typescript): add tool-UI (widget) support to GroundedAgent

### DIFF
--- a/docs/src/content/docs/agents/built-in/grounded-agent.mdx
+++ b/docs/src/content/docs/agents/built-in/grounded-agent.mdx
@@ -8,7 +8,7 @@ The `GroundedAgent` is the framework's answer to LLM hallucination in tool-drive
 A chit-chat turn that calls no tools skips the presenter entirely: the gatherer answers directly in one pass.
 
 :::note
-Tool-UI widgets are supported in Swift and Python — a tool can return a component that the `GroundedAgent` forwards to the caller (see [Tool UI](#tool-ui-widgets) below). TypeScript support is not yet available. Per-phase trace spans remain Swift-only.
+Tool-UI widgets are supported in Swift, Python, and TypeScript — a tool can return a component that the `GroundedAgent` forwards to the caller (see [Tool UI](#tool-ui-widgets) below). Per-phase trace spans remain Swift-only.
 :::
 
 ## How it works
@@ -390,58 +390,102 @@ When the gatherer makes no tool calls, the `GroundedAgent` emits the gatherer's 
 
 <span id="tool-ui-widgets"></span>
 
-*Python only for now; TypeScript support is not yet available.*
-
 A tool can return an interactive UI component (an "MCP App" widget) alongside its text. Instead of a plain string, the tool returns a `ToolResult`:
 
 - `content` — the text added to the model's context (what the gatherer reads).
-- `structured_content` — the data the widget renders from. **Render-only**: never added to the model's context, so the model cannot hallucinate from it. The curator also feeds the presenter from this.
-- `ui` — a `UIPayload`: the self-contained component (its `resource_uri`, `mime_type`, `template`, render-only `structured_content`, and a `UISecurity` policy the host turns into a CSP).
+- `structuredContent` / `structured_content` — the data the widget renders from. **Render-only**: never added to the model's context, so the model cannot hallucinate from it. The curator also feeds the presenter from this.
+- `ui` — a `UIPayload`: the self-contained component (its resource URI, MIME type, template, render-only structured content, and a `UISecurity` policy the host turns into a CSP).
 
-When the turn's primary tool returns a `UIPayload`, the `GroundedAgent` forwards it to the caller on the **streaming path** as the `ui` field of an `AgentStreamResponse`, emitted before the presenter's text streams in. This is governed by `ui_policy` (`UIPolicy.FORWARD`, the default, or `UIPolicy.SUPPRESS` to drop the widget and keep the grounded text only). Drawing the widget is the host's job — the framework only carries the data.
+When the turn's primary tool returns a `UIPayload`, the `GroundedAgent` forwards it to the caller on the **streaming path**, before the presenter's text streams in — in Python as the `ui` field of an `AgentStreamResponse`, in TypeScript as a `{ ui }` chunk at the head of the stream (TS streams carry strings, so the widget rides as its own object chunk). Governed by `uiPolicy` / `ui_policy` (`FORWARD` by default, or `SUPPRESS` to drop the widget and keep the grounded text only). Drawing the widget is the host's job — the framework only carries the data.
 
-```python
-from agent_squad.utils import AgentTool, AgentTools, ToolResult, UIPayload, UISecurity, UIPolicy
-from agent_squad.agents import GroundedAgent, GroundedAgentOptions
+<Tabs syncKey="runtime">
+  <TabItem label="TypeScript" icon="seti:typescript" color="blue">
+    ```typescript
+    import {
+      GroundedAgent, AgentTool, AgentTools, ToolResult, UIPolicy,
+    } from 'agent-squad';
 
-def get_order(order_id: str) -> ToolResult:
-    """Look up an order's status and delivery estimate.
+    const getOrder = (input: { orderId: string }): ToolResult => {
+      const data = { orderId: input.orderId, status: 'In transit', eta: '2026-07-02' };
+      return new ToolResult(
+        `Order ${input.orderId}: ${data.status}, ETA ${data.eta}.`, // text → the gatherer's context
+        data,                                                       // render-only → widget + presenter feed
+        {
+          resourceUri: 'ui://shop/order-card',
+          mimeType: 'text/html;profile=mcp-app',
+          template: "<div class='card'>…render from window.WIDGET_DATA…</div>",
+          structuredContent: data,
+          security: { resourceDomains: ['https://cdn.myshop.com'], prefersBorder: true },
+        },
+      );
+    };
 
-    :param order_id: the order id
-    """
-    data = {"order_id": order_id, "status": "In transit", "eta": "2026-07-02"}
-    return ToolResult(
-        # text → the gatherer's context (so it can reason / follow up)
-        content=f"Order {order_id}: {data['status']}, ETA {data['eta']}.",
-        # render-only → hydrates the widget and the presenter feed, never the model
-        structured_content=data,
-        ui=UIPayload(
-            resource_uri="ui://shop/order-card",
-            mime_type="text/html;profile=mcp-app",
-            template="<div class='card'>…render from window.WIDGET_DATA…</div>",
+    const tools = new AgentTools([new AgentTool({ name: 'get_order', func: getOrder })]);
+
+    const shop = new GroundedAgent({
+      name: 'Shop',
+      description: 'Orders, grounded in real data.',
+      gatherer,                    // built above, with tools
+      presenter,
+      tools,
+      uiPolicy: UIPolicy.FORWARD,  // default; use SUPPRESS for text-only
+    });
+
+    // The widget arrives as a { ui } chunk ahead of the presenter's text chunks:
+    const stream = await shop.processRequest('where is my order #1234?', userId, sessionId, []);
+    for await (const chunk of stream as AsyncIterable<any>) {
+      if (chunk?.ui) renderWidget(chunk.ui);                    // your host renders the component
+      else if (typeof chunk === 'string') process.stdout.write(chunk); // grounded text underneath
+    }
+    ```
+  </TabItem>
+  <TabItem label="Python" icon="seti:python">
+    ```python
+    from agent_squad.utils import AgentTool, AgentTools, ToolResult, UIPayload, UISecurity, UIPolicy
+    from agent_squad.agents import GroundedAgent, GroundedAgentOptions
+
+    def get_order(order_id: str) -> ToolResult:
+        """Look up an order's status and delivery estimate.
+
+        :param order_id: the order id
+        """
+        data = {"order_id": order_id, "status": "In transit", "eta": "2026-07-02"}
+        return ToolResult(
+            # text → the gatherer's context (so it can reason / follow up)
+            content=f"Order {order_id}: {data['status']}, ETA {data['eta']}.",
+            # render-only → hydrates the widget and the presenter feed, never the model
             structured_content=data,
-            security=UISecurity(resource_domains=["https://cdn.myshop.com"], prefers_border=True),
-        ),
-    )
+            ui=UIPayload(
+                resource_uri="ui://shop/order-card",
+                mime_type="text/html;profile=mcp-app",
+                template="<div class='card'>…render from window.WIDGET_DATA…</div>",
+                structured_content=data,
+                security=UISecurity(resource_domains=["https://cdn.myshop.com"], prefers_border=True),
+            ),
+        )
 
-tools = AgentTools([AgentTool(name="get_order", func=get_order, required=["order_id"])])
+    tools = AgentTools([AgentTool(name="get_order", func=get_order, required=["order_id"])])
 
-shop = GroundedAgent(GroundedAgentOptions(
-    name="Shop",
-    description="Orders, grounded in real data.",
-    gatherer=gatherer,          # built as above, with tools=tools
-    presenter=presenter,
-    tools=tools,
-    ui_policy=UIPolicy.FORWARD,  # default; use SUPPRESS for text-only
-))
+    shop = GroundedAgent(GroundedAgentOptions(
+        name="Shop",
+        description="Orders, grounded in real data.",
+        gatherer=gatherer,          # built as above, with tools=tools
+        presenter=presenter,
+        tools=tools,
+        ui_policy=UIPolicy.FORWARD,  # default; use SUPPRESS for text-only
+    ))
 
-# Consume the widget on the stream:
-async for chunk in await shop.process_request("where is my order #1234?", user_id, session_id, []):
-    if chunk.ui is not None:
-        render_widget(chunk.ui)          # your host renders the component
-    elif chunk.text:
-        print(chunk.text, end="")        # the grounded sentence streams underneath
-```
+    # Consume the widget on the stream:
+    async for chunk in await shop.process_request("where is my order #1234?", user_id, session_id, []):
+        if chunk.ui is not None:
+            render_widget(chunk.ui)          # your host renders the component
+        elif chunk.text:
+            print(chunk.text, end="")        # the grounded sentence streams underneath
+    ```
+  </TabItem>
+</Tabs>
+
+In TypeScript, consume the widget by iterating the **agent's** stream directly (as above). Routing a `GroundedAgent` through `AgentSquad.routeRequest` accumulates text for the reply, and its accumulator forwards only text chunks — the `{ ui }` object chunk is dropped there. To render widgets, drive the agent directly. (Python's orchestrator forwards the widget-bearing chunk unchanged, so either path works there.)
 
 An `.app`-only tool (one the widget calls back into, but the model must never see) is kept out of what the model is offered by filtering the provider's tool list to model-visible tools — the same way the widget's Refresh button re-invokes a tool without the LLM's involvement.
 

--- a/typescript/src/agents/groundedAgent.ts
+++ b/typescript/src/agents/groundedAgent.ts
@@ -121,8 +121,16 @@ export class PresenterPrompt {
 
 /** Shared helpers for the gather -> present pattern. */
 export const Grounding = {
-  /** The turn's primary tool: the last call (drives the presenter prompt selection). */
+  /**
+   * The turn's primary tool: the last call that advertised a UI widget, else the last call (matches
+   * Swift). Drives both the presenter prompt and the forwarded widget, so a widget still surfaces
+   * when a non-UI helper runs after the UI tool.
+   */
   primary(results: CapturedToolResult[]): CapturedToolResult | undefined {
+    for (let i = results.length - 1; i >= 0; i--) {
+      const r = results[i];
+      if (r.result instanceof ToolResult && r.result.ui) return r;
+    }
     return results.length ? results[results.length - 1] : undefined;
   },
 

--- a/typescript/src/agents/groundedAgent.ts
+++ b/typescript/src/agents/groundedAgent.ts
@@ -1,6 +1,7 @@
 import { Agent, AgentOptions } from "./agent";
 import { ConversationMessage, ParticipantRole } from "../types";
-import { AgentTool, AgentTools } from "../utils/tool";
+import { AgentTool, AgentTools, ToolResult } from "../utils/tool";
+import { UIPayload, UIPolicy } from "../utils/ui";
 
 /**
  * The 2-LLM grounded (anti-hallucination) pattern as an {@link Agent}.
@@ -10,8 +11,8 @@ import { AgentTool, AgentTools } from "../utils/tool";
  * so it cannot invent values beyond what was fetched. A chit-chat turn that calls no tools is answered
  * in one pass by the gatherer, skipping the presenter.
  *
- * Mirrors the Swift `GroundedAgent`. The tool-UI (widget) and trace-span machinery from the Swift
- * implementation has no equivalent in this tree and is intentionally omitted.
+ * When a tool returns a {@link ToolResult} carrying a UI widget, the primary tool's widget is
+ * forwarded to the caller as a `{ ui }` chunk on the streaming response, governed by `uiPolicy`.
  */
 
 /** The generic grounding instruction: present only the provided data, never invent values. */
@@ -62,8 +63,14 @@ export class DataBlockCurator implements ToolOutputCurator {
 
   /** One section. Also used as {@link PerToolCurator}'s fallback formatter. */
   static section(result: CapturedToolResult): string {
-    const body =
-      typeof result.result === "string" ? result.result : stableStringify(result.result);
+    let value = result.result;
+    if (value instanceof ToolResult) {
+      // Curate from the render-only structured data (the facts), not the widget wrapper. `{}` is
+      // truthy in JS, so check emptiness explicitly rather than `structuredContent || content`.
+      const sc = value.structuredContent;
+      value = sc && typeof sc === "object" && Object.keys(sc).length ? sc : value.content;
+    }
+    const body = typeof value === "string" ? value : stableStringify(value);
     return `### ${result.name}\n${body}`;
   }
 }
@@ -119,6 +126,12 @@ export const Grounding = {
     return results.length ? results[results.length - 1] : undefined;
   },
 
+  /** The widget advertised by the primary tool, if it returned one. */
+  primaryUi(results: CapturedToolResult[]): UIPayload | undefined {
+    const primary = Grounding.primary(results);
+    return primary && primary.result instanceof ToolResult ? primary.result.ui : undefined;
+  },
+
   /**
    * The presenter's user message: question and curated data, tagged so the model can tell them
    * apart.
@@ -146,6 +159,8 @@ export interface GroundedAgentOptions extends AgentOptions {
   curator?: ToolOutputCurator;
   /** Per-tool presenter system prompts. Default: a generic grounding prompt. */
   presenterPrompt?: PresenterPrompt;
+  /** Whether a tool-advertised widget is forwarded to the caller (streaming path only). Default: forward. */
+  uiPolicy?: UIPolicy;
 }
 
 /**
@@ -158,6 +173,7 @@ export class GroundedAgent extends Agent {
   private readonly tools: AgentTools;
   private readonly curator: ToolOutputCurator;
   private readonly presenterPrompt: PresenterPrompt;
+  private readonly uiPolicy: UIPolicy;
 
   constructor(options: GroundedAgentOptions) {
     super(options);
@@ -172,6 +188,7 @@ export class GroundedAgent extends Agent {
     this.tools = options.tools;
     this.curator = options.curator ?? new DataBlockCurator();
     this.presenterPrompt = options.presenterPrompt ?? PresenterPrompt.default();
+    this.uiPolicy = options.uiPolicy ?? UIPolicy.FORWARD;
   }
 
   async processRequest(
@@ -211,13 +228,24 @@ export class GroundedAgent extends Agent {
       );
     }
     const presenterInput = Grounding.presenterMessage(inputText, feed);
-    return this.presenter.processRequest(
+    const presenterResponse = await this.presenter.processRequest(
       presenterInput,
       userId,
       sessionId,
       chatHistory,
       additionalParams
     );
+
+    // Forward the primary tool's widget (if any) as a leading `{ ui }` chunk, then the presenter's
+    // text. Streaming path only — a non-streaming presenter returns a message with no widget channel.
+    const widget = this.uiPolicy === UIPolicy.FORWARD ? Grounding.primaryUi(captured) : undefined;
+    if (widget && GroundedAgent.isAsyncIterable(presenterResponse)) {
+      return (async function* () {
+        yield { ui: widget };
+        yield* presenterResponse as AsyncIterable<any>;
+      })();
+    }
+    return presenterResponse;
   }
 
   /**

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -47,7 +47,10 @@ export { AgentSquad } from "./orchestrator";
 export { AgentOverlapAnalyzer, AnalysisResult } from "./agentOverlapAnalyzer";
 
 export { ConversationMessage, ParticipantRole } from "./types"
-export { AgentTools, AgentTool} from "./utils/tool"
+export { AgentTools, AgentTool, ToolResult } from "./utils/tool"
+export type { ToolFormatter } from "./agents/groundedAgent"
+export { UIPolicy } from "./utils/ui"
+export type { UIPayload, UISecurity } from "./utils/ui"
 export { isClassifierToolInput } from './utils/helpers'
 export { MCPToolProvider, MCPServerConfig } from './tools/mcpToolProvider'
 

--- a/typescript/src/utils/tool.ts
+++ b/typescript/src/utils/tool.ts
@@ -1,10 +1,24 @@
-/**
- * Represents the result of a tool execution
- */
+import { UIPayload } from "./ui";
+
+// Internal wire wrapper (toolUseId + text) that formats a result for the model. Not the same as the
+// public `ToolResult` below, which is what a tool returns.
 export class AgentToolResult {
   constructor(
     public toolUseId: string,
     public content: any
+  ) {}
+}
+
+/**
+ * A tool return that carries render-only data and/or a UI widget. Only `content` (text) is added to
+ * the model's context; `structuredContent` and `ui` never reach the model. Tools that need none of
+ * this can still just return a string.
+ */
+export class ToolResult {
+  constructor(
+    public content: string = "",
+    public structuredContent: any = {},
+    public ui?: UIPayload
   ) {}
 }
 
@@ -192,7 +206,13 @@ export class AgentTools {
       const toolId = getToolId(toolUseBlock);
       const inputData = getInputData(toolUseBlock);
       const result = await this.processTool(toolName, inputData);
-      const toolResult = new AgentToolResult(toolId, result);
+      // A ToolResult carries render-only data/UI; only its text goes to the model. Empty text falls
+      // back to the structured data so the model isn't blind. Plain returns pass through unchanged.
+      const modelContent =
+        result instanceof ToolResult
+          ? result.content || JSON.stringify(result.structuredContent)
+          : result;
+      const toolResult = new AgentToolResult(toolId, modelContent);
       toolResults.push(toolResult);
     }
 

--- a/typescript/src/utils/ui.ts
+++ b/typescript/src/utils/ui.ts
@@ -1,0 +1,38 @@
+/**
+ * Tool-UI (widget) types.
+ *
+ * A tool can return a self-contained UI component (an "MCP App" widget) alongside its text. The host
+ * renders it from `structuredContent`, which is render-only: never added to the model's context, so
+ * the model cannot hallucinate from it. These types carry the data only — drawing the widget is the
+ * host's job.
+ */
+
+/** Security the host enforces when rendering a component (built into a CSP). Undeclared domains are blocked. */
+export interface UISecurity {
+  connectDomains?: string[];
+  resourceDomains?: string[];
+  frameDomains?: string[];
+  permissions?: string[]; // e.g. "camera", "microphone"
+  domain?: string; // dedicated sandbox origin
+  prefersBorder?: boolean;
+}
+
+/**
+ * A widget package advertised by a tool. `structuredContent`/`meta` are render-only — never added to
+ * the model's context. `template` is the component body (HTML, a URL, or a remote-DOM script); the
+ * kind is given by `mimeType`.
+ */
+export interface UIPayload {
+  resourceUri: string; // e.g. "ui://shop/order-card"
+  mimeType: string; // e.g. "text/html;profile=mcp-app"
+  template?: string;
+  structuredContent?: any;
+  meta?: Record<string, any>;
+  security?: UISecurity;
+}
+
+/** Whether an advertised tool UI is surfaced to the caller (decided per agent). */
+export enum UIPolicy {
+  FORWARD = "forward", // surface the widget on the response (default)
+  SUPPRESS = "suppress", // fold the data into the text answer; emit no widget
+}

--- a/typescript/tests/agents/groundedAgent.test.ts
+++ b/typescript/tests/agents/groundedAgent.test.ts
@@ -351,13 +351,50 @@ describe("GroundedAgent", () => {
     expect(Grounding.primaryUi([{ name: "get_order", result: tr }])?.resourceUri).toBe(
       "ui://shop/order-card"
     );
+    // A trailing non-UI tool must not hide an earlier widget (prefers the last UI call; Swift parity).
     expect(
       Grounding.primaryUi([
-        { name: "a", result: tr },
+        { name: "get_order", result: tr },
+        { name: "check_stock", result: "in stock" },
+      ])?.resourceUri
+    ).toBe("ui://shop/order-card");
+    // No UI tool at all → no widget.
+    expect(
+      Grounding.primaryUi([
+        { name: "a", result: "plain" },
         { name: "b", result: "plain" },
       ])
     ).toBeUndefined();
     expect(Grounding.primaryUi([])).toBeUndefined();
+  });
+
+  it("forwards the widget and keys the prompt off the UI tool when a non-UI tool trails it", async () => {
+    // A UI tool followed by a plain non-UI helper.
+    const tools = new AgentTools([
+      new AgentTool({ name: "search_products", func: () => uiToolResult() }),
+      new AgentTool({ name: "check_stock", func: () => "in stock" }),
+    ]);
+    const gatherer = new FakeGatherer(
+      { name: "g", description: "" },
+      tools,
+      [
+        { name: "search_products", args: {} },
+        { name: "check_stock", args: {} },
+      ],
+      "",
+      true
+    );
+    const presenter = new FakePresenter({ name: "p", description: "" }, "done", true);
+    const agent = build(gatherer, presenter, tools, {
+      presenterPrompt: new PresenterPrompt("DEFAULT", { search_products: "PRODUCT PROMPT" }),
+    });
+
+    const result = await agent.processRequest("q", "u", "s", []);
+    const chunks: any[] = [];
+    for await (const chunk of result as AsyncIterable<any>) chunks.push(chunk);
+
+    expect(chunks.filter((c) => c && typeof c === "object" && c.ui)).toHaveLength(1);
+    expect(presenter.systemPrompt).toBe("PRODUCT PROMPT");
   });
 
   // --- Construction guards ---

--- a/typescript/tests/agents/groundedAgent.test.ts
+++ b/typescript/tests/agents/groundedAgent.test.ts
@@ -10,7 +10,8 @@ import {
   CapturedToolResult,
 } from "../../src/agents/groundedAgent";
 import { ConversationMessage, ParticipantRole } from "../../src/types";
-import { AgentTool, AgentTools } from "../../src/utils/tool";
+import { AgentTool, AgentTools, ToolResult } from "../../src/utils/tool";
+import { UIPolicy, UIPayload } from "../../src/utils/ui";
 
 interface ToolCall {
   name: string;
@@ -256,6 +257,107 @@ describe("GroundedAgent", () => {
     const result = await agent.processRequest("hi", "u", "s", []);
     expect(await toText(result)).toBe("just chatting");
     expect(presenter.called).toBe(false);
+  });
+
+  // --- Tool UI (widget) forwarding ---
+
+  const uiToolResult = () => {
+    const payload: UIPayload = {
+      resourceUri: "ui://shop/order-card",
+      mimeType: "text/html;profile=mcp-app",
+      template: "<div>card</div>",
+      structuredContent: { status: "shipped" },
+    };
+    return new ToolResult("Order: shipped", { status: "shipped" }, payload);
+  };
+
+  it("forwards the primary tool's widget before the presenter text on a tool turn", async () => {
+    const tools = makeTools();
+    const gatherer = new FakeGatherer(
+      { name: "g", description: "" },
+      tools,
+      [{ name: "search_products", args: {} }],
+      "",
+      true
+    );
+    (tools.tools[0] as any).func = () => uiToolResult();
+    const presenter = new FakePresenter({ name: "p", description: "" }, "Your order shipped.", true);
+    const agent = build(gatherer, presenter, tools);
+
+    const result = await agent.processRequest("order?", "u", "s", []);
+    const chunks: any[] = [];
+    for await (const chunk of result as AsyncIterable<any>) chunks.push(chunk);
+
+    expect(chunks[0].ui.resourceUri).toBe("ui://shop/order-card");
+    expect(chunks[chunks.length - 1]).toBe("Your order shipped.");
+    // The presenter is fed the structured facts, not the widget wrapper.
+    expect(presenter.receivedInput).toContain('"status": "shipped"');
+  });
+
+  it("emits no widget when uiPolicy is SUPPRESS", async () => {
+    const tools = makeTools();
+    const gatherer = new FakeGatherer(
+      { name: "g", description: "" },
+      tools,
+      [{ name: "search_products", args: {} }],
+      "",
+      true
+    );
+    (tools.tools[0] as any).func = () => uiToolResult();
+    const presenter = new FakePresenter({ name: "p", description: "" }, "text only", true);
+    const agent = build(gatherer, presenter, tools, { uiPolicy: UIPolicy.SUPPRESS });
+
+    const result = await agent.processRequest("q", "u", "s", []);
+    const chunks: any[] = [];
+    for await (const chunk of result as AsyncIterable<any>) chunks.push(chunk);
+    expect(chunks.some((c) => c && typeof c === "object" && c.ui)).toBe(false);
+    expect(chunks.join("")).toBe("text only");
+  });
+
+  it("curates a ToolResult from its structuredContent", () => {
+    const out = new DataBlockCurator().curate([
+      { name: "get_product", result: new ToolResult("ignored text", { price: 90 }) },
+    ]);
+    expect(out).toContain("### get_product");
+    expect(out).toContain('"price": 90');
+    expect(out).not.toContain("ignored text");
+  });
+
+  it("curates from content when a ToolResult has empty structuredContent", () => {
+    // `{}` is truthy in JS — verifies the explicit-emptiness check, not a naive `sc || content`.
+    const out = new DataBlockCurator().curate([{ name: "t", result: new ToolResult("plain text") }]);
+    expect(out).toBe("### t\nplain text");
+  });
+
+  it("returns a plain message with no widget for a non-streaming presenter", async () => {
+    const tools = makeTools();
+    const gatherer = new FakeGatherer(
+      { name: "g", description: "" },
+      tools,
+      [{ name: "search_products", args: {} }]
+    );
+    (tools.tools[0] as any).func = () => uiToolResult();
+    const presenter = new FakePresenter({ name: "p", description: "" }, "Your order shipped.");
+    const agent = build(gatherer, presenter, tools);
+
+    const result = await agent.processRequest("order?", "u", "s", []);
+    // Non-streaming: a ConversationMessage (not a stream), and no widget channel.
+    expect(typeof (result as any)[Symbol.asyncIterator]).toBe("undefined");
+    expect((result as ConversationMessage).content?.[0].text).toBe("Your order shipped.");
+  });
+
+  it("Grounding.primaryUi returns the primary tool's widget", () => {
+    const tr = uiToolResult();
+    expect(Grounding.primaryUi([{ name: "get_order", result: tr }])?.resourceUri).toBe(
+      "ui://shop/order-card"
+    );
+    expect(
+      Grounding.primaryUi([
+        { name: "a", result: tr },
+        { name: "b", result: "plain" },
+      ])
+    ).toBeUndefined();
+    expect(Grounding.primaryUi([])).toBeUndefined();
   });
 
   // --- Construction guards ---

--- a/typescript/tests/utils/tool.test.ts
+++ b/typescript/tests/utils/tool.test.ts
@@ -1,0 +1,62 @@
+import { AgentTools, AgentTool, AgentToolResult, ToolResult } from "../../src/utils/tool";
+
+const getToolUseBlock = (block: any) => block.toolUse ?? null;
+const getToolName = (b: any) => b.name;
+const getToolId = (b: any) => b.toolUseId;
+const getInputData = (b: any) => b.input;
+
+function bedrockResponse(toolName: string, toolUseId: string, input: any) {
+  return { role: "assistant", content: [{ toolUse: { name: toolName, toolUseId, input } }] };
+}
+
+describe("AgentTools.toolHandler ToolResult routing", () => {
+  it("routes only a ToolResult's text to the model", async () => {
+    const tools = new AgentTools([
+      new AgentTool({
+        name: "get_order",
+        func: (input: any) => new ToolResult(`Order ${input.orderId}`, { id: input.orderId }),
+      }),
+    ]);
+
+    const results = await tools.toolHandler(
+      bedrockResponse("get_order", "1", { orderId: "42" }),
+      getToolUseBlock,
+      getToolName,
+      getToolId,
+      getInputData
+    );
+
+    expect(results[0]).toBeInstanceOf(AgentToolResult);
+    expect(results[0].content).toBe("Order 42"); // structured data + widget never reach the model
+  });
+
+  it("falls back to structuredContent JSON when a ToolResult has no text", async () => {
+    const tools = new AgentTools([
+      new AgentTool({ name: "t", func: (input: any) => new ToolResult("", { x: input.x }) }),
+    ]);
+
+    const results = await tools.toolHandler(
+      bedrockResponse("t", "1", { x: "hi" }),
+      getToolUseBlock,
+      getToolName,
+      getToolId,
+      getInputData
+    );
+
+    expect(results[0].content).toBe(JSON.stringify({ x: "hi" }));
+  });
+
+  it("passes a plain string return through unchanged", async () => {
+    const tools = new AgentTools([new AgentTool({ name: "t", func: () => "just text" })]);
+
+    const results = await tools.toolHandler(
+      bedrockResponse("t", "1", {}),
+      getToolUseBlock,
+      getToolName,
+      getToolId,
+      getInputData
+    );
+
+    expect(results[0].content).toBe("just text");
+  });
+});


### PR DESCRIPTION
## Issue Link

Closes #592

## Summary

TypeScript parity for the tool-UI (widget) capability added to Python in #591: a tool can return a widget that the `GroundedAgent` forwards to the caller alongside the grounded text. Additive and fully backward compatible.

**Stacked on #591** (base is `feat/python-grounded-agent-tool-ui` so the diff is TypeScript-only). Merge #591 first; GitHub will retarget this to `main`.

## Changes

- New `UIPayload` / `UISecurity` interfaces and `UIPolicy` enum in `src/utils/ui.ts`.
- New `ToolResult` class (`content`, `structuredContent`, `ui?`) a tool may return instead of a string. `AgentTools.toolHandler` routes only `content` to the model (empty content → JSON of `structuredContent`); string-returning tools take the identical path.
- `GroundedAgent`: a `uiPolicy` (`FORWARD` default / `SUPPRESS`) that forwards the primary tool's widget as a `{ ui }` chunk at the head of the streaming response; the curator feeds the presenter from `structuredContent`.
- Barrel exports; docs updated with a TypeScript tab.

## User experience

A tool returns `new ToolResult(text, data, uiPayload)`. Consuming the agent's stream directly, the caller receives a `{ ui }` chunk (before the grounded text) and renders it. TS streams strings, so the widget is delivered as its own object chunk rather than Python's `AgentStreamResponse.ui` — a deliberate, documented divergence.

## Checklist

- [x] Backward compatible — `ToolResult` opt-in; `{ ui }` chunk only when a tool returns one + `uiPolicy` FORWARD + streaming presenter; existing tools/streams unchanged
- [x] Lightweight / additive — no new dependencies (UI types are plain interfaces)
- [x] Tests added; `npm run build`, `npm run lint`, `npm run coverage` (158 tests, 16 suites) all green
- [x] Docs updated with a TypeScript example
- [x] Reviewed by the TypeScript expert (APPROVED)

Note: the orchestrator's streaming accumulator forwards text only, so widgets are consumed by driving the agent directly (documented). MCP-provider UI passthrough and the non-streaming widget surface are deliberate follow-ups, matching Python.

Code written by Claude (Opus 4.8), architected and approved by @cornelcroi.