### PR TITLE
feat(typescript): MCP tool-UI passthrough in MCPToolProvider

### DIFF
--- a/docs/src/content/docs/agents/mcp-tool-provider.mdx
+++ b/docs/src/content/docs/agents/mcp-tool-provider.mdx
@@ -245,13 +245,11 @@ openai_agent = OpenAIAgent(OpenAIAgentOptions(
 
 ## Tool UI (widgets)
 
-If an MCP server advertises a UI widget on a tool — via `_meta.ui.resourceUri` (or the OpenAI `openai/outputTemplate` alias), the same "MCP Apps" contract ChatGPT Apps use — `MCPToolProvider` surfaces it instead of flattening the result to text. On a call it reads the result's `structuredContent`, fetches the advertised UI resource (`resources/read`, cached), and returns a [`ToolResult`](/agent-squad/agents/built-in/grounded-agent/#tool-ui-widgets) carrying a `UIPayload` (its `resource_uri`, `mime_type`, `template`, render-only `structured_content`, and `meta`). Tools whose `_meta.ui.visibility` excludes `model` stay callable but are never advertised to the LLM.
+If an MCP server advertises a UI widget on a tool — via `_meta.ui.resourceUri` (or the OpenAI `openai/outputTemplate` alias), the same "MCP Apps" contract ChatGPT Apps use — `MCPToolProvider` surfaces it instead of flattening the result to text. On a call it reads the result's `structuredContent`, fetches the advertised UI resource (`resources/read`, cached), and returns a [`ToolResult`](/agent-squad/agents/built-in/grounded-agent/#tool-ui-widgets) carrying a `UIPayload` (its resource URI, MIME type, template, render-only structured content, and `meta`). Tools whose `_meta.ui.visibility` excludes `model` stay callable but are never advertised to the LLM.
 
 Pair the provider with a [`GroundedAgent`](/agent-squad/agents/built-in/grounded-agent/) and the widget is forwarded to the caller on the streaming response, exactly like a native tool that returns a `UIPayload` — so the same MCP server that backs a ChatGPT App renders its widgets here. For a server that advertises no `_meta.ui`, the model sees the same text as before.
 
-:::note
-Tool-UI passthrough is available in the Python `MCPToolProvider` today; TypeScript support is in progress. (Native tools that return a `ToolResult` with a widget already work in both languages.)
-:::
+Available in the Python and TypeScript `MCPToolProvider`. In TypeScript, consume the widget by driving the agent directly (the orchestrator's streaming accumulator forwards text only) — see the [GroundedAgent tool-UI notes](/agent-squad/agents/built-in/grounded-agent/#tool-ui-widgets).
 
 ## Configuration reference
 

--- a/typescript/src/tools/mcpToolProvider.ts
+++ b/typescript/src/tools/mcpToolProvider.ts
@@ -1,5 +1,21 @@
-import { AgentTool, AgentToolCallbacks, AgentToolResult, AgentTools } from "../utils/tool";
+import { AgentTool, AgentToolCallbacks, AgentToolResult, AgentTools, ToolResult } from "../utils/tool";
+import { UIPayload } from "../utils/ui";
 import { ConversationMessage } from "../types";
+
+/** The advertised UI template URI: `_meta.ui.resourceUri`, or the OpenAI `openai/outputTemplate` alias. */
+function uiResourceUri(meta: any): string | undefined {
+  if (!meta || typeof meta !== "object") return undefined;
+  const fromUi = meta.ui?.resourceUri;
+  if (typeof fromUi === "string") return fromUi;
+  const alias = meta["openai/outputTemplate"];
+  return typeof alias === "string" ? alias : undefined;
+}
+
+/** Whether the model may be offered the tool. `_meta.ui.visibility` lists audiences; absent → both. */
+function modelVisible(meta: any): boolean {
+  const visibility = meta?.ui?.visibility;
+  return Array.isArray(visibility) ? visibility.includes("model") : true;
+}
 
 /**
  * Configuration for a single MCP server connection.
@@ -55,6 +71,11 @@ export class MCPToolProvider extends AgentTools {
   private clients: any[] = [];
   /** Map from MCP tool name → the client that owns it */
   private toolClientMap: Map<string, any> = new Map();
+  /** Map from MCP tool name → its advertised UI resource URI (if any) */
+  private toolUiMap: Map<string, string> = new Map();
+  /** Per-client cache of fetched UI templates, keyed by resource URI */
+  private templateCache: WeakMap<object, Map<string, { mimeType: string; body: string }>> =
+    new WeakMap();
   private connected = false;
 
   constructor(servers: MCPServerConfig[], callbacks?: AgentToolCallbacks) {
@@ -176,31 +197,33 @@ export class MCPToolProvider extends AgentTools {
       const { tools: mcpTools } = await client.listTools();
 
       for (const mcpTool of mcpTools) {
-        this.toolClientMap.set(mcpTool.name, client);
+        const toolName = mcpTool.name;
+        this.toolClientMap.set(toolName, client);
+
+        const meta = mcpTool._meta;
+        const ui = uiResourceUri(meta);
+        if (ui) this.toolUiMap.set(toolName, ui);
 
         const schema = mcpTool.inputSchema ?? { type: "object", properties: {} };
         const properties: Record<string, any> = schema.properties ?? {};
         const required: string[] = schema.required ?? [];
 
-        // Build an AgentTool with a dummy func — actual execution goes through
-        // MCP via our overridden toolHandler.
+        // A real func: the gatherer invokes it through the base tool loop, which lets a UI-aware
+        // consumer (GroundedAgent) capture the ToolResult it returns — including any widget.
         const agentTool = new AgentTool({
-          name: mcpTool.name,
-          description: mcpTool.description ?? `MCP tool: ${mcpTool.name}`,
+          name: toolName,
+          description: mcpTool.description ?? `MCP tool: ${toolName}`,
           properties,
           required,
-          func: async () => {
-            // Placeholder — never called; MCPToolProvider.toolHandler handles
-            // execution directly via the MCP client.
-            return null;
-          },
+          func: async (input: any) => this.callMCPTool(toolName, input),
         });
 
         // Store the raw MCP input schema so format methods can pass it through
         // unchanged (it is already valid JSON Schema).
         (agentTool as any)._mcpInputSchema = schema;
 
-        allTools.push(agentTool);
+        // App-only tools stay callable (in toolClientMap) but are never advertised to the model.
+        if (modelVisible(meta)) allTools.push(agentTool);
       }
     }
 
@@ -275,9 +298,12 @@ export class MCPToolProvider extends AgentTools {
   // ---------------------------------------------------------------------------
 
   /**
-   * Handles tool-use blocks from the LLM response by calling the appropriate
-   * MCP server. Mirrors the {@link AgentTools#toolHandler} signature exactly
-   * so it works inside BedrockLLMAgent, AnthropicAgent, etc. without changes.
+   * Runs each tool-use block by invoking the tool's `func` (our MCP call, returning a
+   * {@link ToolResult}) with the full input, then routes only its text to the model. Calling `func`
+   * is what lets a UI-aware consumer such as `GroundedAgent` capture the widget-carrying result.
+   *
+   * We invoke `func` directly (rather than delegating to the base loop) so the tool receives its
+   * full input — the base `processTool` would unwrap a `messages` key and drop the other arguments.
    */
   override async toolHandler(
     response: any,
@@ -302,8 +328,16 @@ export class MCPToolProvider extends AgentTools {
       const toolId = getToolId(toolUseBlock);
       const inputData = getInputData(toolUseBlock);
 
-      const result = await this.callMCPTool(toolName, inputData);
-      toolResults.push(new AgentToolResult(toolId, result));
+      // Model-visible tools carry a real func (captured by GroundedAgent); app-only / unknown tools
+      // aren't advertised, so fall back to a direct MCP call.
+      const tool = this.tools.find((t) => t.name === toolName);
+      const result = tool ? await tool.func(inputData) : await this.callMCPTool(toolName, inputData);
+
+      const content =
+        result instanceof ToolResult
+          ? result.content || JSON.stringify(result.structuredContent)
+          : result;
+      toolResults.push(new AgentToolResult(toolId, content));
     }
 
     return toolResults;
@@ -313,10 +347,10 @@ export class MCPToolProvider extends AgentTools {
   // Internal helpers
   // ---------------------------------------------------------------------------
 
-  private async callMCPTool(toolName: string, inputData: any): Promise<string> {
+  private async callMCPTool(toolName: string, inputData: any): Promise<ToolResult> {
     const client = this.toolClientMap.get(toolName);
     if (!client) {
-      return `MCP tool '${toolName}' not found`;
+      return new ToolResult(`MCP tool '${toolName}' not found`);
     }
 
     try {
@@ -325,15 +359,64 @@ export class MCPToolProvider extends AgentTools {
         arguments: inputData ?? {},
       });
 
+      const text = this.extractTextFromContent(mcpResult.content);
       if (mcpResult.isError) {
-        const errorText = this.extractTextFromContent(mcpResult.content);
-        return `Error from MCP tool '${toolName}': ${errorText}`;
+        return new ToolResult(`Error from MCP tool '${toolName}': ${text}`);
       }
 
-      return this.extractTextFromContent(mcpResult.content);
+      const structured = mcpResult.structuredContent ?? {};
+      let ui: UIPayload | undefined;
+      const resourceUri = this.toolUiMap.get(toolName);
+      if (resourceUri) {
+        const template = await this.readTemplate(client, resourceUri);
+        if (template) {
+          ui = {
+            resourceUri,
+            mimeType: template.mimeType,
+            template: template.body,
+            structuredContent: structured,
+            meta: mcpResult._meta,
+          };
+        }
+      }
+      return new ToolResult(text, structured, ui);
     } catch (error: any) {
-      return `Error calling MCP tool '${toolName}': ${error?.message ?? String(error)}`;
+      return new ToolResult(
+        `Error calling MCP tool '${toolName}': ${error?.message ?? String(error)}`
+      );
     }
+  }
+
+  /** Fetch (and cache, per client) a UI template resource. A resource is text or a base64 blob. */
+  private async readTemplate(
+    client: any,
+    resourceUri: string
+  ): Promise<{ mimeType: string; body: string } | undefined> {
+    const cached = this.templateCache.get(client);
+    if (cached?.has(resourceUri)) return cached.get(resourceUri);
+
+    let template: { mimeType: string; body: string } | undefined;
+    try {
+      const res = await client.readResource({ uri: resourceUri });
+      const first = res?.contents?.[0];
+      if (first) {
+        const mimeType: string = first.mimeType ?? "text/html;profile=mcp-app";
+        let body: string | undefined = typeof first.text === "string" ? first.text : undefined;
+        if (body === undefined && typeof first.blob === "string") {
+          body = Buffer.from(first.blob, "base64").toString("utf-8");
+        }
+        if (body !== undefined) template = { mimeType, body };
+      }
+    } catch {
+      template = undefined;
+    }
+
+    if (template) {
+      const byUri = cached ?? new Map<string, { mimeType: string; body: string }>();
+      byUri.set(resourceUri, template);
+      this.templateCache.set(client, byUri);
+    }
+    return template;
   }
 
   private extractTextFromContent(content: any): string {
@@ -367,6 +450,8 @@ export class MCPToolProvider extends AgentTools {
     }
     this.clients = [];
     this.toolClientMap.clear();
+    this.toolUiMap.clear();
+    this.templateCache = new WeakMap();
     this.tools = [];
     this.connected = false;
   }

--- a/typescript/src/tools/mcpToolProvider.ts
+++ b/typescript/src/tools/mcpToolProvider.ts
@@ -330,8 +330,12 @@ export class MCPToolProvider extends AgentTools {
 
       // Model-visible tools carry a real func (captured by GroundedAgent); app-only / unknown tools
       // aren't advertised, so fall back to a direct MCP call.
+      // Only model-visible tools (in this.tools) are executable via the model loop. An app-only or
+      // unknown name is rejected here — an app-only MCP tool must never be invocable by the model.
       const tool = this.tools.find((t) => t.name === toolName);
-      const result = tool ? await tool.func(inputData) : await this.callMCPTool(toolName, inputData);
+      const result = tool
+        ? await tool.func(inputData)
+        : new ToolResult(`MCP tool '${toolName}' not found`);
 
       const content =
         result instanceof ToolResult

--- a/typescript/tests/mcpToolProvider.test.ts
+++ b/typescript/tests/mcpToolProvider.test.ts
@@ -12,12 +12,14 @@ const mockCallTool = jest.fn();
 const mockListTools = jest.fn();
 const mockConnect = jest.fn();
 const mockClose = jest.fn();
+const mockReadResource = jest.fn();
 
 class MockClient {
   connect = mockConnect;
   listTools = mockListTools;
   callTool = mockCallTool;
   close = mockClose;
+  readResource = mockReadResource;
 }
 
 class MockStdioTransport {
@@ -37,7 +39,7 @@ jest.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({ SSEClientTransport
 // ---------------------------------------------------------------------------
 
 import { MCPToolProvider, MCPServerConfig } from "../src/tools/mcpToolProvider";
-import { AgentTools, AgentToolResult } from "../src/utils/tool";
+import { AgentTools, AgentToolResult, ToolResult } from "../src/utils/tool";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -421,5 +423,157 @@ describe("MCPToolProvider", () => {
     await expect(badProvider.ensureConnected()).rejects.toThrow(
       "requires a 'url' field"
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool UI (widgets)
+  // -------------------------------------------------------------------------
+
+  const uiTool = (extraMeta: any = { ui: { resourceUri: "ui://shop/order-card" } }) => ({
+    name: "get_order",
+    description: "Order status",
+    inputSchema: { type: "object", properties: {}, required: [] },
+    _meta: extraMeta,
+  });
+
+  async function connectedProvider(): Promise<MCPToolProvider> {
+    const p = new MCPToolProvider([{ type: "stdio", command: "x" }]);
+    await p.ensureConnected();
+    return p;
+  }
+
+  it("returns a ToolResult with a UIPayload for a tool advertising _meta.ui", async () => {
+    mockListTools.mockResolvedValue({ tools: [uiTool()] });
+    mockCallTool.mockResolvedValue({
+      isError: false,
+      content: [{ type: "text", text: "Order 42: shipped" }],
+      structuredContent: { status: "shipped" },
+      _meta: { a: 1 },
+    });
+    mockReadResource.mockResolvedValue({
+      contents: [{ uri: "ui://shop/order-card", mimeType: "text/html;profile=mcp-app", text: "<div>card</div>" }],
+    });
+
+    const p = await connectedProvider();
+    const result: any = await p.tools.find((t) => t.name === "get_order")!.func({ orderId: "42" });
+
+    expect(result).toBeInstanceOf(ToolResult);
+    expect(result.content).toBe("Order 42: shipped"); // only text goes to the model
+    expect(result.structuredContent).toEqual({ status: "shipped" });
+    expect(result.ui.resourceUri).toBe("ui://shop/order-card");
+    expect(result.ui.mimeType).toBe("text/html;profile=mcp-app");
+    expect(result.ui.template).toBe("<div>card</div>");
+    expect(result.ui.structuredContent).toEqual({ status: "shipped" });
+    expect(result.ui.meta).toEqual({ a: 1 }); // _meta forwarded to the UI, never the model
+  });
+
+  it("falls back to the mcp-app mime type when the resource omits mimeType", async () => {
+    mockListTools.mockResolvedValue({ tools: [uiTool()] });
+    mockCallTool.mockResolvedValue({ isError: false, content: [{ type: "text", text: "ok" }], structuredContent: {} });
+    mockReadResource.mockResolvedValue({ contents: [{ text: "<div/>" }] }); // no mimeType
+
+    const p = await connectedProvider();
+    const result: any = await p.tools.find((t) => t.name === "get_order")!.func({});
+    expect(result.ui.mimeType).toBe("text/html;profile=mcp-app");
+  });
+
+  it("forwards the full input even when it contains a 'messages' key", async () => {
+    mockListTools.mockResolvedValue({
+      tools: [{ name: "chat", inputSchema: { type: "object", properties: { messages: { type: "array" } } } }],
+    });
+    mockCallTool.mockResolvedValue({ isError: false, content: [{ type: "text", text: "ok" }] });
+
+    const p = await connectedProvider();
+    const resp = makeBedrockResponse("chat", "1", { messages: [{ role: "user" }], extra: 1 });
+    await p.toolHandler(resp, bedrockGetToolUseBlock, bedrockGetToolName, bedrockGetToolId, bedrockGetInputData);
+
+    // The whole object is sent to the server — not just inputData.messages.
+    expect(mockCallTool).toHaveBeenCalledWith({
+      name: "chat",
+      arguments: { messages: [{ role: "user" }], extra: 1 },
+    });
+  });
+
+  it("handles undefined tool input without throwing", async () => {
+    mockListTools.mockResolvedValue({
+      tools: [{ name: "ping", inputSchema: { type: "object", properties: {} } }],
+    });
+    mockCallTool.mockResolvedValue({ isError: false, content: [{ type: "text", text: "pong" }] });
+
+    const p = await connectedProvider();
+    const resp = makeBedrockResponse("ping", "1", undefined);
+    const results = await p.toolHandler(
+      resp,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+    expect(results[0].content).toBe("pong");
+    expect(mockCallTool).toHaveBeenCalledWith({ name: "ping", arguments: {} });
+  });
+
+  it("reads the openai/outputTemplate alias", async () => {
+    mockListTools.mockResolvedValue({ tools: [uiTool({ "openai/outputTemplate": "ui://alias" })] });
+    mockCallTool.mockResolvedValue({ isError: false, content: [{ type: "text", text: "ok" }], structuredContent: {} });
+    mockReadResource.mockResolvedValue({ contents: [{ mimeType: "text/html", text: "<b>x</b>" }] });
+
+    const p = await connectedProvider();
+    const result: any = await p.tools.find((t) => t.name === "get_order")!.func({});
+    expect(result.ui.resourceUri).toBe("ui://alias");
+  });
+
+  it("decodes a base64 blob template", async () => {
+    mockListTools.mockResolvedValue({ tools: [uiTool()] });
+    mockCallTool.mockResolvedValue({ isError: false, content: [{ type: "text", text: "ok" }], structuredContent: {} });
+    const blob = Buffer.from("<div>from blob</div>").toString("base64");
+    mockReadResource.mockResolvedValue({ contents: [{ mimeType: "text/html", blob }] });
+
+    const p = await connectedProvider();
+    const result: any = await p.tools.find((t) => t.name === "get_order")!.func({});
+    expect(result.ui.template).toBe("<div>from blob</div>");
+  });
+
+  it("degrades to text when the UI resource fetch fails", async () => {
+    mockListTools.mockResolvedValue({ tools: [uiTool()] });
+    mockCallTool.mockResolvedValue({
+      isError: false,
+      content: [{ type: "text", text: "Order: shipped" }],
+      structuredContent: { s: 1 },
+    });
+    mockReadResource.mockRejectedValue(new Error("read failed"));
+
+    const p = await connectedProvider();
+    const result: any = await p.tools.find((t) => t.name === "get_order")!.func({});
+    expect(result.ui).toBeUndefined();
+    expect(result.content).toBe("Order: shipped");
+    expect(result.structuredContent).toEqual({ s: 1 });
+  });
+
+  it("fetches the UI template once (cached per client)", async () => {
+    mockListTools.mockResolvedValue({ tools: [uiTool()] });
+    mockCallTool.mockResolvedValue({ isError: false, content: [{ type: "text", text: "ok" }], structuredContent: {} });
+    mockReadResource.mockResolvedValue({ contents: [{ mimeType: "text/html", text: "<div/>" }] });
+
+    const p = await connectedProvider();
+    const tool = p.tools.find((t) => t.name === "get_order")!;
+    await tool.func({});
+    await tool.func({});
+    expect(mockReadResource).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides app-only tools from the model but keeps them connected", async () => {
+    const appOnly = {
+      name: "refresh_order",
+      inputSchema: { type: "object", properties: {} },
+      _meta: { ui: { visibility: ["app"] } },
+    };
+    mockListTools.mockResolvedValue({ tools: [uiTool(), appOnly] });
+
+    const p = await connectedProvider();
+    // Only the model-visible tool is advertised...
+    expect(p.tools.map((t) => t.name)).toEqual(["get_order"]);
+    const bedrock = await p.toBedrockFormat();
+    expect(bedrock.map((r: any) => r.toolSpec.name)).toEqual(["get_order"]);
   });
 });

--- a/typescript/tests/mcpToolProvider.test.ts
+++ b/typescript/tests/mcpToolProvider.test.ts
@@ -40,6 +40,9 @@ jest.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({ SSEClientTransport
 
 import { MCPToolProvider, MCPServerConfig } from "../src/tools/mcpToolProvider";
 import { AgentTools, AgentToolResult, ToolResult } from "../src/utils/tool";
+import { GroundedAgent } from "../src/agents/groundedAgent";
+import { Agent, AgentOptions } from "../src/agents/agent";
+import { ConversationMessage, ParticipantRole } from "../src/types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -85,6 +88,33 @@ const bedrockGetToolUseBlock = (block: any) => block.toolUse ?? null;
 const bedrockGetToolName = (b: any) => b.name;
 const bedrockGetToolId = (b: any) => b.toolUseId;
 const bedrockGetInputData = (b: any) => b.input;
+
+// A gatherer that drives an MCP tool the way a real agent does — through the provider's
+// toolHandler (the old code bypassed each tool's func here, so GroundedAgent captured nothing).
+class McpFakeGatherer extends Agent {
+  constructor(options: AgentOptions, private readonly provider: MCPToolProvider) {
+    super(options);
+  }
+  async processRequest(): Promise<ConversationMessage> {
+    await this.provider.toolHandler(
+      makeBedrockResponse("get_order", "1", { orderId: "42" }),
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+    return { role: ParticipantRole.ASSISTANT, content: [{ text: "" }] };
+  }
+}
+
+class McpFakePresenter extends Agent {
+  receivedInput?: string;
+  setSystemPrompt(_template?: string): void {}
+  async processRequest(input: string): Promise<ConversationMessage> {
+    this.receivedInput = input;
+    return { role: ParticipantRole.ASSISTANT, content: [{ text: "presented" }] };
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -560,6 +590,29 @@ describe("MCPToolProvider", () => {
     await tool.func({});
     await tool.func({});
     expect(mockReadResource).toHaveBeenCalledTimes(1);
+  });
+
+  it("GroundedAgent captures an MCP tool result (regression: MCP grounding was silently skipped)", async () => {
+    mockListTools.mockResolvedValue({ tools: [uiTool()] });
+    mockCallTool.mockResolvedValue({
+      isError: false,
+      content: [{ type: "text", text: "Order 42: shipped" }],
+      structuredContent: { status: "shipped" },
+    });
+    mockReadResource.mockResolvedValue({ contents: [{ mimeType: "text/html", text: "<div/>" }] });
+
+    const provider = await connectedProvider();
+    const gatherer = new McpFakeGatherer({ name: "g", description: "" }, provider);
+    const presenter = new McpFakePresenter({ name: "p", description: "" });
+    const agent = new GroundedAgent({ name: "Shop", description: "", gatherer, presenter, tools: provider });
+
+    const result: any = await agent.processRequest("where is my order?", "u", "s", []);
+
+    // The presenter ran on the captured MCP facts. Before the fix the tool call was never captured,
+    // so GroundedAgent saw no tools, skipped the presenter, and returned the gatherer's empty draft.
+    expect(presenter.receivedInput).toContain("get_order");
+    expect(presenter.receivedInput).toContain("shipped");
+    expect(result.content[0].text).toBe("presented");
   });
 
   it("hides app-only tools from the model but keeps them connected", async () => {

--- a/typescript/tests/mcpToolProvider.test.ts
+++ b/typescript/tests/mcpToolProvider.test.ts
@@ -629,4 +629,27 @@ describe("MCPToolProvider", () => {
     const bedrock = await p.toBedrockFormat();
     expect(bedrock.map((r: any) => r.toolSpec.name)).toEqual(["get_order"]);
   });
+
+  it("rejects a model call to an app-only tool instead of executing it", async () => {
+    const appOnly = {
+      name: "refresh_order",
+      inputSchema: { type: "object", properties: {} },
+      _meta: { ui: { visibility: ["app"] } },
+    };
+    mockListTools.mockResolvedValue({ tools: [uiTool(), appOnly] });
+    mockCallTool.mockResolvedValue({ isError: false, content: [{ type: "text", text: "should not run" }] });
+
+    const p = await connectedProvider();
+    const resp = makeBedrockResponse("refresh_order", "1", {});
+    const results = await p.toolHandler(
+      resp,
+      bedrockGetToolUseBlock,
+      bedrockGetToolName,
+      bedrockGetToolId,
+      bedrockGetInputData
+    );
+
+    expect(results[0].content).toContain("not found"); // the model can't tell it exists
+    expect(mockCallTool).not.toHaveBeenCalled(); // and it was NOT executed via the model loop
+  });
 });


### PR DESCRIPTION
## Issue Link

Closes #596

## Summary

Makes the TypeScript `MCPToolProvider` carry a server-advertised widget through to the caller instead of flattening the MCP result to text — so a TS `GroundedAgent` can render the widgets of the same MCP server that backs a ChatGPT App. Mirrors the Swift and Python (#595) providers.

**Stacked on #593** (base `feat/typescript-grounded-agent-tool-ui`, which adds TS `ToolResult`/`UIPayload`). Merge #593 first; GitHub retargets this to `main`.

## Changes

- Parse each tool's `_meta` at connect time: UI resource URI (`_meta.ui.resourceUri` or the OpenAI `openai/outputTemplate` alias) and visibility. App-only tools (visibility excludes `model`) are filtered out of `this.tools` — never advertised — while staying in `toolClientMap`.
- Each MCP tool's `func` is now real: it calls the server and returns a `ToolResult`. `callMCPTool` reads `structuredContent`, and when the tool advertised a UI it fetches the resource (`readResource`, cached per client) and builds a `UIPayload`.
- `toolHandler` invokes `func` with the **full** input and routes only the text to the model.
- **Also fixes a latent bug:** `GroundedAgent` captures tool results via the tool's `func`; the previous dummy `func` + bespoke `toolHandler` override bypassed it, so MCP tool calls weren't captured at all. Now they are.

## User experience

Point a `GroundedAgent`'s gatherer at an MCP server whose tool advertises a widget; consume the agent's stream and the caller gets the widget (a `{ ui }` chunk) before the grounded text.

## Checklist

- [x] Backward compatible — a server with no `_meta.ui` sends the same model-facing text (success / isError / exception / unknown-tool strings all match the old override); full input preserved (no `messages`-key drop, no throw on undefined)
- [x] Lightweight / additive — no new dependency (`@modelcontextprotocol/sdk` stays an optional peer)
- [x] Tests added (widget passthrough, alias, blob, fetch-failure, cache, visibility, `messages`-key + undefined input); `npm run build`/`lint`/`coverage` green (169 tests, 16 suites)
- [x] Docs updated (MCP tool-provider page Tool UI section)
- [x] Reviewed by the TypeScript expert; the one REQUIRED item (full-input handling vs base `processTool`) fixed

Note: touches the same docs section as #595 (Python MCP) — resolve any overlap by keeping this three-language wording.

Code written by Claude (Opus 4.8), architected and approved by @cornelcroi.