### PR TITLE
ci: exclude the flaky Apple Podcasts link from the Lychee link-check

### DIFF
--- a/.github/workflows/ts-run-lint.yml
+++ b/.github/workflows/ts-run-lint.yml
@@ -29,7 +29,7 @@ jobs:
         uses: lycheeverse/lychee-action@c053181aa0c3d17606addfe97a9075a32723548a
         with:
           fail: true
-          args: --scheme=https . --exclude-all-private --accept '999, 429, 403' --max-concurrency 1 --retry-wait-time 5 --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" --exclude https://docs.anthropic.com/en/api/getting-started
+          args: --scheme=https . --exclude-all-private --accept '999, 429, 403' --max-concurrency 1 --retry-wait-time 5 --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" --exclude https://docs.anthropic.com/en/api/getting-started --exclude https://podcasts.apple.com
       - name: Install dependencies
         run: npm install
       - name: Run linting

--- a/.github/workflows/ts-run-tests.yml
+++ b/.github/workflows/ts-run-tests.yml
@@ -27,7 +27,7 @@ jobs:
         uses: lycheeverse/lychee-action@c053181aa0c3d17606addfe97a9075a32723548a
         with:
           fail: true
-          args: --scheme=https . --exclude-all-private --accept '999, 429, 403' --max-concurrency 1 --retry-wait-time 5 --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+          args: --scheme=https . --exclude-all-private --accept '999, 429, 403' --max-concurrency 1 --retry-wait-time 5 --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" --exclude https://podcasts.apple.com
       - name: Install dependencies
         run: npm install
       - name: Run tests


### PR DESCRIPTION
## Issue Link

Closes #600

## Summary

The Lychee link-check intermittently fails on the Apple Podcasts link in `README.md` (`[500] Internal Server Error` — Apple 500s the crawler unpredictably), red-flagging any PR that touches markdown. Adds `podcasts.apple.com` to Lychee's `--exclude` in both `ts-run-lint.yml` and `ts-run-tests.yml`.

## Changes

- `--exclude https://podcasts.apple.com` appended to the lychee args in both workflows.

## Checklist

- [x] CI-only change; no library code touched
- [x] Narrow exclude (the flaky host only), consistent across both lychee jobs

Code written by Claude (Opus 4.8), architected and approved by @cornelcroi.