### PR TITLE
fix(python): don't send an empty tool list to Bedrock/Anthropic

### DIFF
--- a/python/src/agent_squad/agents/anthropic_agent.py
+++ b/python/src/agent_squad/agents/anthropic_agent.py
@@ -175,7 +175,11 @@ class AnthropicAgent(Agent):
                 json_input[key] = value
 
         if self.tool_config:
-            json_input["tools"] = self._prepare_tool_config()
+            tools = self._prepare_tool_config()
+            # Only attach a non-empty tool list (e.g. an MCP provider whose tools are all app-only
+            # yields none the model can call).
+            if tools:
+                json_input["tools"] = tools
 
         return json_input
 

--- a/python/src/agent_squad/agents/bedrock_llm_agent.py
+++ b/python/src/agent_squad/agents/bedrock_llm_agent.py
@@ -159,7 +159,11 @@ class BedrockLLMAgent(Agent):
             command["additionalModelRequestFields"] = self.additional_model_request_fields
 
         if self.tool_config:
-            command["toolConfig"] = self._prepare_tool_config()
+            tool_config = self._prepare_tool_config()
+            # Skip an empty tool list — Bedrock rejects toolConfig.tools with fewer than 1 entry
+            # (e.g. an MCP provider whose tools are all app-only / hidden from the model).
+            if tool_config.get("tools"):
+                command["toolConfig"] = tool_config
 
         return command
 

--- a/python/src/tests/agents/test_anthropic_agent.py
+++ b/python/src/tests/agents/test_anthropic_agent.py
@@ -837,3 +837,24 @@ async def test_handle_streaming_with_tool_use():
 
     # Verify the messages list was updated with the tool response
     assert input_data["messages"][-1] == tool_response
+
+def test_empty_tool_config_omits_tools(mock_anthropic):
+    """An all-hidden/empty tool provider must not attach an empty tools list."""
+    options = AnthropicAgentOptions(
+        name="TestAgent", description="A test agent", client=Anthropic(api_key="test"),
+        tool_config={"tool": AgentTools([])},
+    )
+    agent = AnthropicAgent(options)
+    json_input = agent._build_input([], "system prompt")
+    assert "tools" not in json_input
+
+
+def test_nonempty_tool_config_attaches_tools(mock_anthropic):
+    tools = AgentTools([AgentTool(name="t", func=lambda x: "ok")])
+    options = AnthropicAgentOptions(
+        name="TestAgent", description="A test agent", client=Anthropic(api_key="test"),
+        tool_config={"tool": tools},
+    )
+    agent = AnthropicAgent(options)
+    json_input = agent._build_input([], "system prompt")
+    assert "tools" in json_input and len(json_input["tools"]) == 1

--- a/python/src/tests/agents/test_bedrock_llm_agent.py
+++ b/python/src/tests/agents/test_bedrock_llm_agent.py
@@ -832,3 +832,26 @@ def test_additional_model_request_fields(mock_boto3_client):
     # Verify topP is present when thinking is not enabled
     assert "topP" in result["inferenceConfig"]
     assert result["inferenceConfig"]["topP"] == 0.9  # Default value
+
+
+def test_empty_tool_config_omits_toolconfig(mock_boto3_client):
+    """An all-hidden/empty tool provider must not send toolConfig — Bedrock rejects tools: []."""
+    options = BedrockLLMAgentOptions(
+        name="TestAgent", description="A test agent", region="us-west-2",
+        tool_config={"tool": AgentTools([])},
+    )
+    agent = BedrockLLMAgent(options)
+    command = agent._build_conversation_command([], "system prompt")
+    assert "toolConfig" not in command
+
+
+def test_nonempty_tool_config_sets_toolconfig(mock_boto3_client):
+    tools = AgentTools([AgentTool(name="t", func=lambda x: "ok")])
+    options = BedrockLLMAgentOptions(
+        name="TestAgent", description="A test agent", region="us-west-2",
+        tool_config={"tool": tools},
+    )
+    agent = BedrockLLMAgent(options)
+    command = agent._build_conversation_command([], "system prompt")
+    assert "toolConfig" in command
+    assert len(command["toolConfig"]["tools"]) == 1


### PR DESCRIPTION
## Issue Link

Closes #602

## Summary

When a tool provider yields no model-visible tools (e.g. an MCP server whose tools are all app-only — reachable after the visibility filtering in #595), `BedrockLLMAgent` still sent `toolConfig: {tools: []}`, which Bedrock rejects (`toolConfig.tools` needs ≥1 entry), and `AnthropicAgent` attached an empty `tools: []`. This guards both.

## Changes

- `BedrockLLMAgent._build_conversation_command`: only set `toolConfig` when the prepared tool list is non-empty.
- `AnthropicAgent._build_input`: only attach `tools` when non-empty.
- Tests for both (empty → omitted; non-empty → present). OpenAI agent has no tool_config path.

## Checklist

- [x] Backward compatible — only change is not sending an empty tool list; non-empty configs unchanged
- [x] Tests added; `ruff check src/agent_squad` clean; agent tests pass
- [x] Independent of the widget PRs (general robustness fix), based on `main`

Code written by Claude (Opus 4.8), architected and approved by @cornelcroi.