### PR TITLE
feat(python): MCP tool-UI passthrough in MCPToolProvider

### DIFF
--- a/docs/src/content/docs/agents/mcp-tool-provider.mdx
+++ b/docs/src/content/docs/agents/mcp-tool-provider.mdx
@@ -243,6 +243,16 @@ openai_agent = OpenAIAgent(OpenAIAgentOptions(
   </TabItem>
 </Tabs>
 
+## Tool UI (widgets)
+
+If an MCP server advertises a UI widget on a tool — via `_meta.ui.resourceUri` (or the OpenAI `openai/outputTemplate` alias), the same "MCP Apps" contract ChatGPT Apps use — `MCPToolProvider` surfaces it instead of flattening the result to text. On a call it reads the result's `structuredContent`, fetches the advertised UI resource (`resources/read`, cached), and returns a [`ToolResult`](/agent-squad/agents/built-in/grounded-agent/#tool-ui-widgets) carrying a `UIPayload` (its `resource_uri`, `mime_type`, `template`, render-only `structured_content`, and `meta`). Tools whose `_meta.ui.visibility` excludes `model` stay callable but are never advertised to the LLM.
+
+Pair the provider with a [`GroundedAgent`](/agent-squad/agents/built-in/grounded-agent/) and the widget is forwarded to the caller on the streaming response, exactly like a native tool that returns a `UIPayload` — so the same MCP server that backs a ChatGPT App renders its widgets here. For a server that advertises no `_meta.ui`, the model sees the same text as before.
+
+:::note
+Tool-UI passthrough is available in the Python `MCPToolProvider` today; TypeScript support is in progress. (Native tools that return a `ToolResult` with a widget already work in both languages.)
+:::
+
 ## Configuration reference
 
 ### MCPServerConfig

--- a/python/src/agent_squad/tools/mcp_tool_provider.py
+++ b/python/src/agent_squad/tools/mcp_tool_provider.py
@@ -29,6 +29,9 @@ Requires the ``mcp`` extra::
 
 from __future__ import annotations
 
+import base64
+import json
+
 try:
     from mcp import ClientSession
     from mcp.client.stdio import stdio_client, StdioServerParameters
@@ -39,11 +42,14 @@ except ImportError as exc:
         "Install it with: pip install agent-squad[mcp]"
     ) from exc
 
+from pydantic import AnyUrl  # mcp depends on pydantic, so it's available whenever the import above succeeds
+
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from agent_squad.types import AgentProviderType, ConversationMessage, ParticipantRole
-from agent_squad.utils.tool import AgentTools, AgentToolCallbacks
+from agent_squad.utils.tool import AgentTools, AgentToolCallbacks, ToolResult
+from agent_squad.utils.ui import UIPayload
 
 
 @dataclass
@@ -68,6 +74,48 @@ class MCPServerConfig:
     env: Optional[dict[str, str]] = None
     url: Optional[str] = None
     headers: Optional[dict[str, str]] = None
+
+
+def _meta_dict(mcp_tool: Any) -> Optional[dict[str, Any]]:
+    """The tool's ``_meta`` (MCP Apps UI metadata); the SDK exposes it as ``.meta``."""
+    return getattr(mcp_tool, "meta", None) or getattr(mcp_tool, "_meta", None)
+
+
+def _ui_resource_uri(meta: Optional[dict[str, Any]]) -> Optional[str]:
+    """The advertised UI template URI: ``_meta.ui.resourceUri``, or the OpenAI
+    ``openai/outputTemplate`` alias. Tolerant of absent/wrong-typed fields."""
+    if not isinstance(meta, dict):
+        return None
+    ui = meta.get("ui")
+    if isinstance(ui, dict) and isinstance(ui.get("resourceUri"), str):
+        return ui["resourceUri"]
+    alias = meta.get("openai/outputTemplate")
+    return alias if isinstance(alias, str) else None
+
+
+def _model_visible(meta: Optional[dict[str, Any]]) -> bool:
+    """Whether the model may be offered the tool. ``_meta.ui.visibility`` lists audiences
+    (``model`` / ``app``); absent means both (the MCP default)."""
+    if not isinstance(meta, dict):
+        return True
+    ui = meta.get("ui")
+    if not isinstance(ui, dict):
+        return True
+    visibility = ui.get("visibility")
+    if not isinstance(visibility, list):
+        return True
+    return "model" in visibility
+
+
+@dataclass
+class _MCPToolEntry:
+    """Per-tool state: owning session, the raw MCP tool, its advertised UI resource URI (if any),
+    and whether the model may see it (app-only tools stay callable but unadvertised)."""
+
+    session: Any
+    tool: Any
+    ui: Optional[str] = None
+    model_visible: bool = True
 
 
 class MCPToolProvider(AgentTools):
@@ -102,8 +150,11 @@ class MCPToolProvider(AgentTools):
         super().__init__(tools=[], callbacks=callbacks)
 
         self._servers = servers
-        # Maps tool_name → (ClientSession, mcp_tool)
-        self._tool_map: dict[str, tuple[Any, Any]] = {}
+        # Maps tool_name → _MCPToolEntry
+        self._tool_map: dict[str, _MCPToolEntry] = {}
+        # Caches fetched UI templates: (session id, resourceUri) → (mime_type, body).
+        # Keyed by session too, so two servers advertising the same URI can't collide.
+        self._template_cache: dict[tuple[int, str], tuple[str, str]] = {}
         self._connected = False
         # Keep hold of context-manager stacks so we can exit them on disconnect
         self._cm_stack: list[Any] = []
@@ -172,7 +223,13 @@ class MCPToolProvider(AgentTools):
 
             tools_result = await session.list_tools()
             for mcp_tool in tools_result.tools:
-                self._tool_map[mcp_tool.name] = (session, mcp_tool)
+                meta = _meta_dict(mcp_tool)
+                self._tool_map[mcp_tool.name] = _MCPToolEntry(
+                    session=session,
+                    tool=mcp_tool,
+                    ui=_ui_resource_uri(meta),
+                    model_visible=_model_visible(meta),
+                )
 
         self._connected = True
 
@@ -197,6 +254,7 @@ class MCPToolProvider(AgentTools):
         self._cm_stack = []
 
         self._tool_map = {}
+        self._template_cache = {}
         self._connected = False
 
     # ------------------------------------------------------------------
@@ -246,12 +304,16 @@ class MCPToolProvider(AgentTools):
                 tool_name, input_data, result, metadata={"agent_info": agent_info}
             )
 
+            # Only the text reaches the model; the structured data + widget ride on the ToolResult
+            # for a UI-aware consumer (e.g. GroundedAgent), captured via on_tool_end above.
+            model_text = result.content or json.dumps(result.structured_content, default=str)
+
             if provider_type == AgentProviderType.BEDROCK.value:
                 tool_results.append(
                     {
                         "toolResult": {
                             "toolUseId": tool_id,
-                            "content": [{"text": result}],
+                            "content": [{"text": model_text}],
                         }
                     }
                 )
@@ -260,7 +322,7 @@ class MCPToolProvider(AgentTools):
                     {
                         "type": "tool_result",
                         "tool_use_id": tool_id,
-                        "content": result,
+                        "content": model_text,
                     }
                 )
 
@@ -270,31 +332,76 @@ class MCPToolProvider(AgentTools):
             )
         return {"role": ParticipantRole.USER.value, "content": tool_results}
 
-    async def _call_mcp_tool(self, tool_name: str, input_data: dict) -> str:
-        """Call a tool on the appropriate MCP server and return a string result."""
-        if tool_name not in self._tool_map:
-            return f"Tool '{tool_name}' not found in any connected MCP server"
+    async def _call_mcp_tool(self, tool_name: str, input_data: dict) -> ToolResult:
+        """Call a tool on the appropriate MCP server.
 
-        session, _ = self._tool_map[tool_name]
+        Returns a :class:`~agent_squad.utils.tool.ToolResult` carrying the text (added to the model's
+        context), the render-only ``structured_content``, and a ``UIPayload`` widget when the tool
+        advertised one via its ``_meta.ui`` (fetched from the server as a resource)."""
+        entry = self._tool_map.get(tool_name)
+        if entry is None:
+            return ToolResult(content=f"Tool '{tool_name}' not found in any connected MCP server")
+
         try:
-            call_result = await session.call_tool(tool_name, input_data)
+            call_result = await entry.session.call_tool(tool_name, input_data)
         except Exception as exc:  # noqa: BLE001
-            return f"Error calling tool '{tool_name}': {exc}"
+            return ToolResult(content=f"Error calling tool '{tool_name}': {exc}")
 
-        if getattr(call_result, "isError", False):
-            # Surface the error text back to the model so it can react
-            parts = [
-                getattr(item, "text", str(item))
-                for item in (call_result.content or [])
-            ]
-            return f"Tool error: {' '.join(parts)}" if parts else "Tool returned an error"
-
-        # Collect text content from the result
         parts = [
             getattr(item, "text", str(item))
-            for item in (call_result.content or [])
+            for item in (getattr(call_result, "content", None) or [])
         ]
-        return "\n".join(parts) if parts else ""
+        text = "\n".join(parts)
+
+        if getattr(call_result, "isError", False):
+            # Surface the error text back to the model so it can react.
+            return ToolResult(content=f"Tool error: {text}" if text else "Tool returned an error")
+
+        structured = getattr(call_result, "structuredContent", None) or {}
+
+        ui: Optional[UIPayload] = None
+        if entry.ui:
+            template = await self._template_for(entry.session, entry.ui)
+            if template is not None:
+                mime_type, body = template
+                ui = UIPayload(
+                    resource_uri=entry.ui,
+                    mime_type=mime_type,
+                    template=body,
+                    structured_content=structured,
+                    meta=getattr(call_result, "meta", None),
+                )
+
+        return ToolResult(content=text, structured_content=structured, ui=ui)
+
+    async def _template_for(self, session: Any, resource_uri: str) -> Optional[tuple[str, str]]:
+        """Fetch (and cache) a UI template resource by URI. Returns ``(mime_type, body)`` or ``None``.
+
+        A resource arrives as text or as a base64 ``blob``; the blob is decoded as UTF-8 markup."""
+        cache_key = (id(session), resource_uri)
+        if cache_key in self._template_cache:
+            return self._template_cache[cache_key]
+        try:
+            read_result = await session.read_resource(AnyUrl(resource_uri))
+        except Exception:  # noqa: BLE001
+            return None
+        contents = getattr(read_result, "contents", None) or []
+        if not contents:
+            return None
+        first = contents[0]
+        mime_type = getattr(first, "mimeType", None) or "text/html;profile=mcp-app"
+        body = getattr(first, "text", None)
+        if body is None:
+            blob = getattr(first, "blob", None)
+            if isinstance(blob, str):
+                try:
+                    body = base64.b64decode(blob).decode("utf-8")
+                except Exception:  # noqa: BLE001
+                    body = None
+        if body is None:
+            return None
+        self._template_cache[cache_key] = (mime_type, body)
+        return (mime_type, body)
 
     # ------------------------------------------------------------------
     # Format conversion helpers
@@ -310,7 +417,10 @@ class MCPToolProvider(AgentTools):
             connect lazily via :meth:`tool_handler`.
         """
         result = []
-        for tool_name, (_session, mcp_tool) in self._tool_map.items():
+        for tool_name, entry in self._tool_map.items():
+            if not entry.model_visible:
+                continue  # app-only tool: callable by the UI, never advertised to the model
+            mcp_tool = entry.tool
             input_schema = (
                 mcp_tool.inputSchema
                 if isinstance(mcp_tool.inputSchema, dict)
@@ -330,7 +440,10 @@ class MCPToolProvider(AgentTools):
     def to_claude_format(self) -> list[dict[str, Any]]:
         """Return MCP tools in the Anthropic / Claude ``input_schema`` format."""
         result = []
-        for tool_name, (_session, mcp_tool) in self._tool_map.items():
+        for tool_name, entry in self._tool_map.items():
+            if not entry.model_visible:
+                continue  # app-only tool: callable by the UI, never advertised to the model
+            mcp_tool = entry.tool
             input_schema = (
                 mcp_tool.inputSchema
                 if isinstance(mcp_tool.inputSchema, dict)
@@ -352,7 +465,10 @@ class MCPToolProvider(AgentTools):
     def to_openai_format(self) -> list[dict[str, Any]]:
         """Return MCP tools in the OpenAI function-calling format."""
         result = []
-        for tool_name, (_session, mcp_tool) in self._tool_map.items():
+        for tool_name, entry in self._tool_map.items():
+            if not entry.model_visible:
+                continue  # app-only tool: callable by the UI, never advertised to the model
+            mcp_tool = entry.tool
             input_schema = (
                 mcp_tool.inputSchema
                 if isinstance(mcp_tool.inputSchema, dict)

--- a/python/src/tests/tools/test_mcp_tool_provider.py
+++ b/python/src/tests/tools/test_mcp_tool_provider.py
@@ -5,31 +5,46 @@ All MCP transport and session interactions are mocked — no real server require
 
 from __future__ import annotations
 
+import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from types import SimpleNamespace
 
 from agent_squad.types import AgentProviderType, ConversationMessage, ParticipantRole
+from agent_squad.utils.tool import ToolResult, AgentToolCallbacks
 
 
 # ---------------------------------------------------------------------------
 # Helpers to build mock MCP objects
 # ---------------------------------------------------------------------------
 
-def _make_mcp_tool(name: str, description: str = "", properties: dict | None = None, required: list | None = None):
-    """Return a mock object shaped like an mcp Tool."""
+def _make_mcp_tool(name: str, description: str = "", properties: dict | None = None,
+                   required: list | None = None, meta: dict | None = None):
+    """Return a mock object shaped like an mcp Tool (``meta`` == the SDK's ``_meta`` alias)."""
     input_schema = {
         "type": "object",
         "properties": properties or {"query": {"type": "string", "description": "search query"}},
         "required": required or ["query"],
     }
-    return SimpleNamespace(name=name, description=description, inputSchema=input_schema)
+    return SimpleNamespace(name=name, description=description, inputSchema=input_schema, meta=meta)
 
 
-def _make_call_result(text: str, is_error: bool = False):
+def _make_call_result(text: str, is_error: bool = False, structured_content: dict | None = None,
+                      meta: dict | None = None):
     """Return a mock object shaped like an mcp CallToolResult."""
     content_item = SimpleNamespace(text=text)
-    return SimpleNamespace(isError=is_error, content=[content_item])
+    return SimpleNamespace(isError=is_error, content=[content_item],
+                           structuredContent=structured_content, meta=meta)
+
+
+def _make_read_resource_result(text: str, mime_type: str = "text/html;profile=mcp-app"):
+    """Return a mock object shaped like an mcp ReadResourceResult (text content)."""
+    return SimpleNamespace(contents=[SimpleNamespace(uri="ui://x", mimeType=mime_type, text=text)])
+
+
+def _make_read_resource_blob_result(blob_b64: str, mime_type: str = "text/html;profile=mcp-app"):
+    """Return a ReadResourceResult whose single content is a base64 blob (no text)."""
+    return SimpleNamespace(contents=[SimpleNamespace(uri="ui://x", mimeType=mime_type, blob=blob_b64)])
 
 
 def _make_list_tools_result(tools):
@@ -64,7 +79,9 @@ def mock_mcp_modules():
 
 def _build_provider(mocks, tools: list, server_type: str = "stdio"):
     """Helper that returns an MCPToolProvider pre-wired with mock internals."""
-    from agent_squad.tools.mcp_tool_provider import MCPToolProvider, MCPServerConfig
+    from agent_squad.tools.mcp_tool_provider import (
+        MCPToolProvider, MCPServerConfig, _MCPToolEntry, _meta_dict, _ui_resource_uri, _model_visible,
+    )
 
     if server_type == "stdio":
         cfg = MCPServerConfig(type="stdio", command="uvx", args=["my-server"])
@@ -73,11 +90,14 @@ def _build_provider(mocks, tools: list, server_type: str = "stdio"):
 
     provider = MCPToolProvider([cfg])
 
-    # Pre-populate the tool map so we skip the real async connect path
+    # Pre-populate the tool map so we skip the real async connect path (mirrors _ensure_connected).
     mock_session = AsyncMock()
     mock_session.call_tool = AsyncMock()
     for t in tools:
-        provider._tool_map[t.name] = (mock_session, t)
+        meta = _meta_dict(t)
+        provider._tool_map[t.name] = _MCPToolEntry(
+            session=mock_session, tool=t, ui=_ui_resource_uri(meta), model_visible=_model_visible(meta),
+        )
     provider._connected = True
 
     return provider, mock_session
@@ -462,3 +482,168 @@ def test_multiple_tools_format(mock_mcp_modules):
 
     names_openai = {r["function"]["name"] for r in openai_result}
     assert names_openai == {"tool_a", "tool_b", "tool_c"}
+
+
+# ---------------------------------------------------------------------------
+# Tool UI (widget) passthrough
+# ---------------------------------------------------------------------------
+
+def test_ui_resource_uri_helper():
+    from agent_squad.tools.mcp_tool_provider import _ui_resource_uri
+    assert _ui_resource_uri({"ui": {"resourceUri": "ui://a"}}) == "ui://a"
+    assert _ui_resource_uri({"openai/outputTemplate": "ui://b"}) == "ui://b"  # OpenAI alias
+    assert _ui_resource_uri({}) is None
+    assert _ui_resource_uri(None) is None
+
+
+def test_model_visible_helper():
+    from agent_squad.tools.mcp_tool_provider import _model_visible
+    assert _model_visible(None) is True
+    assert _model_visible({}) is True
+    assert _model_visible({"ui": {"visibility": ["model", "app"]}}) is True
+    assert _model_visible({"ui": {"visibility": ["model"]}}) is True
+    assert _model_visible({"ui": {"visibility": ["app"]}}) is False
+
+
+def test_app_only_tools_hidden_from_model_but_callable(mock_mcp_modules):
+    visible = _make_mcp_tool("get_order", "visible")
+    app_only = _make_mcp_tool("refresh_order", "app only", meta={"ui": {"visibility": ["app"]}})
+    provider, _ = _build_provider(mock_mcp_modules, [visible, app_only])
+
+    assert {r["toolSpec"]["name"] for r in provider.to_bedrock_format()} == {"get_order"}
+    assert {r["name"] for r in provider.to_claude_format()} == {"get_order"}
+    assert {r["function"]["name"] for r in provider.to_openai_format()} == {"get_order"}
+    # app-only tool is not advertised to the model but stays callable
+    assert "refresh_order" in provider._tool_map
+
+
+@pytest.mark.asyncio
+async def test_tool_handler_widget_passthrough(mock_mcp_modules):
+    tool = _make_mcp_tool("get_order", "Order status", meta={"ui": {"resourceUri": "ui://shop/order-card"}})
+    provider, mock_session = _build_provider(mock_mcp_modules, [tool])
+    mock_session.call_tool.return_value = _make_call_result(
+        "Order 42: shipped", structured_content={"status": "shipped"}, meta={"a": 1}
+    )
+    mock_session.read_resource = AsyncMock(return_value=_make_read_resource_result("<div>card</div>"))
+
+    captured: dict = {}
+
+    class _CB(AgentToolCallbacks):
+        async def on_tool_end(self, tool_name, payload_input, output, *a, **k):
+            captured["out"] = output
+
+    provider.callbacks = _CB()
+
+    bedrock_response = SimpleNamespace(
+        content=[{"toolUse": {"name": "get_order", "toolUseId": "1", "input": {"orderId": "42"}}}]
+    )
+    result = await provider.tool_handler(AgentProviderType.BEDROCK.value, bedrock_response, [])
+
+    # The model receives only the text.
+    assert result.content[0]["toolResult"]["content"][0]["text"] == "Order 42: shipped"
+    # The capture seam (what GroundedAgent reads) gets a ToolResult carrying the widget.
+    out = captured["out"]
+    assert isinstance(out, ToolResult)
+    assert out.structured_content == {"status": "shipped"}
+    assert out.ui is not None
+    assert out.ui.resource_uri == "ui://shop/order-card"
+    assert out.ui.mime_type == "text/html;profile=mcp-app"
+    assert out.ui.template == "<div>card</div>"
+    assert out.ui.structured_content == {"status": "shipped"}
+    mock_session.read_resource.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tool_handler_no_ui_returns_plain_toolresult(mock_mcp_modules):
+    tool = _make_mcp_tool("weather", "Get weather")  # no _meta.ui
+    provider, mock_session = _build_provider(mock_mcp_modules, [tool])
+    mock_session.call_tool.return_value = _make_call_result("Sunny", structured_content={"t": 25})
+    mock_session.read_resource = AsyncMock()
+
+    captured: dict = {}
+
+    class _CB(AgentToolCallbacks):
+        async def on_tool_end(self, tool_name, payload_input, output, *a, **k):
+            captured["out"] = output
+
+    provider.callbacks = _CB()
+
+    bedrock_response = SimpleNamespace(
+        content=[{"toolUse": {"name": "weather", "toolUseId": "1", "input": {}}}]
+    )
+    await provider.tool_handler(AgentProviderType.BEDROCK.value, bedrock_response, [])
+
+    out = captured["out"]
+    assert isinstance(out, ToolResult)
+    assert out.ui is None
+    mock_session.read_resource.assert_not_called()  # no resource fetch without an advertised UI
+
+
+@pytest.mark.asyncio
+async def test_template_cache_fetches_once(mock_mcp_modules):
+    tool = _make_mcp_tool("get_order", "Order", meta={"ui": {"resourceUri": "ui://shop/order-card"}})
+    provider, mock_session = _build_provider(mock_mcp_modules, [tool])
+    mock_session.call_tool.return_value = _make_call_result("ok", structured_content={"x": 1})
+    mock_session.read_resource = AsyncMock(return_value=_make_read_resource_result("<div>card</div>"))
+
+    await provider._call_mcp_tool("get_order", {})
+    await provider._call_mcp_tool("get_order", {})
+    mock_session.read_resource.assert_called_once()  # cached after the first fetch
+
+
+@pytest.mark.asyncio
+async def test_widget_template_from_blob(mock_mcp_modules):
+    import base64
+    tool = _make_mcp_tool("get_order", "Order", meta={"ui": {"resourceUri": "ui://shop/order-card"}})
+    provider, mock_session = _build_provider(mock_mcp_modules, [tool])
+    mock_session.call_tool.return_value = _make_call_result("ok", structured_content={"x": 1})
+    blob = base64.b64encode("<div>from blob</div>".encode()).decode()
+    mock_session.read_resource = AsyncMock(return_value=_make_read_resource_blob_result(blob))
+
+    result = await provider._call_mcp_tool("get_order", {})
+    assert result.ui is not None
+    assert result.ui.template == "<div>from blob</div>"  # base64 blob decoded as UTF-8
+
+
+@pytest.mark.asyncio
+async def test_widget_fetch_failure_degrades_to_text(mock_mcp_modules):
+    tool = _make_mcp_tool("get_order", "Order", meta={"ui": {"resourceUri": "ui://shop/order-card"}})
+    provider, mock_session = _build_provider(mock_mcp_modules, [tool])
+    mock_session.call_tool.return_value = _make_call_result("Order 42: shipped", structured_content={"s": 1})
+    mock_session.read_resource = AsyncMock(side_effect=RuntimeError("resource read failed"))
+
+    result = await provider._call_mcp_tool("get_order", {})
+    # Resource fetch failed → no widget, but the grounded text and structured data still come through.
+    assert result.ui is None
+    assert result.content == "Order 42: shipped"
+    assert result.structured_content == {"s": 1}
+
+
+@pytest.mark.asyncio
+async def test_empty_content_falls_back_to_structured_json(mock_mcp_modules):
+    tool = _make_mcp_tool("stats", "Stats")
+    provider, mock_session = _build_provider(mock_mcp_modules, [tool])
+    # No text content, but structured data present.
+    mock_session.call_tool.return_value = SimpleNamespace(
+        isError=False, content=[], structuredContent={"count": 3}, meta=None
+    )
+    bedrock_response = SimpleNamespace(
+        content=[{"toolUse": {"name": "stats", "toolUseId": "1", "input": {}}}]
+    )
+    result = await provider.tool_handler(AgentProviderType.BEDROCK.value, bedrock_response, [])
+    # Model receives the JSON of structured_content rather than an empty string.
+    assert result.content[0]["toolResult"]["content"][0]["text"] == json.dumps({"count": 3}, default=str)
+
+
+@pytest.mark.asyncio
+async def test_app_only_tool_still_callable(mock_mcp_modules):
+    app_only = _make_mcp_tool("refresh_order", "app only", meta={"ui": {"visibility": ["app"]}})
+    provider, mock_session = _build_provider(mock_mcp_modules, [app_only])
+    mock_session.call_tool.return_value = _make_call_result("refreshed", structured_content={"s": 2})
+
+    # Not advertised to the model...
+    assert provider.to_bedrock_format() == []
+    # ...but the UI can still invoke it directly.
+    result = await provider._call_mcp_tool("refresh_order", {})
+    assert result.content == "refreshed"
+    assert result.structured_content == {"s": 2}


### PR DESCRIPTION
## Issue Link

Closes #594

## Summary

Makes the Python `MCPToolProvider` surface a server-advertised widget (`_meta.ui` / `openai/outputTemplate`) as a `ToolResult` with a `UIPayload` instead of flattening the result to text — so a Python `GroundedAgent` renders the widgets of the same MCP server that backs a ChatGPT App. Mirrors the Swift provider.

(Rebased onto `main` after #591 merged; supersedes the original #595, which GitHub auto-closed when the stacked base branch was deleted.)

## Changes

- Parse each tool's `_meta` (ui resource URI + visibility); app-only tools filtered out of `to_*_format` but stay callable.
- `_call_mcp_tool` returns a `ToolResult` (text → content, `structuredContent`, `read_resource`-fetched `UIPayload`, cached per session).
- `tool_handler` passes the `ToolResult` to `on_tool_end` (GroundedAgent capture) and routes the text to the model.
- Docs: Tool UI section on the MCP tool-provider page.

## Checklist

- [x] Backward compatible — a server with no `_meta.ui` sends the same text; no new dependency
- [x] Tests (widget/blob/fetch-failure/visibility/cache); ruff clean; python-expert APPROVED

Code written by Claude (Opus 4.8), architected and approved by @cornelcroi.