### PR TITLE
feat(examples): add runnable MCP shop server + app toggle

### DIFF
--- a/examples/mcp-shop-server/README.md
+++ b/examples/mcp-shop-server/README.md
@@ -12,7 +12,8 @@ tool's data — no HTML, no web view.
 
 ```bash
 pip install -r requirements.txt
-python shop_server.py          # serves on http://127.0.0.1:8000/mcp
+python shop_server.py                   # serves on http://127.0.0.1:8000/mcp (loopback)
+HOST=0.0.0.0 python shop_server.py      # bind to the LAN, for a physical device
 ```
 
 ## Point the app at it
@@ -24,7 +25,8 @@ static let mcpServerURL: String? = "http://127.0.0.1:8000/mcp"
 ```
 
 Leave it `nil` to use the app's native `ShopToolProvider` instead. On the iOS Simulator,
-`127.0.0.1` reaches your Mac; on a device, use your Mac's LAN IP.
+`127.0.0.1` reaches your Mac. For a physical device, start the server with `HOST=0.0.0.0` (see
+above) and use your Mac's LAN IP in the URL.
 
 ## Tools
 

--- a/examples/mcp-shop-server/README.md
+++ b/examples/mcp-shop-server/README.md
@@ -1,0 +1,43 @@
+# Shop MCP server (sample)
+
+A tiny [MCP](https://modelcontextprotocol.io) server for the [ChatGPTStyleChat](../swift/ChatGPTStyleChat)
+Swift sample. It exposes an order-lookup tool that advertises a **UI widget**, over streamable HTTP,
+so the native app can point at it instead of its built-in in-app tool.
+
+It shows the same contract ChatGPT Apps use: a tool returns `structuredContent` and advertises
+`_meta.ui.resourceUri`. The app renders that widget as a native SwiftUI card, hydrated from the
+tool's data — no HTML, no web view.
+
+## Run it
+
+```bash
+pip install -r requirements.txt
+python shop_server.py          # serves on http://127.0.0.1:8000/mcp
+```
+
+## Point the app at it
+
+In the Swift sample, set the toggle in `Config.swift`:
+
+```swift
+static let mcpServerURL: String? = "http://127.0.0.1:8000/mcp"
+```
+
+Leave it `nil` to use the app's native `ShopToolProvider` instead. On the iOS Simulator,
+`127.0.0.1` reaches your Mac; on a device, use your Mac's LAN IP.
+
+## Tools
+
+| tool | visibility | notes |
+|------|-----------|-------|
+| `get_order(orderId)` | `model`, `app` | Order status + delivery estimate. Callable by the model; advertises the widget. |
+| `refresh_order(orderId)` | `app` | Same data, marked app-only — never offered to the model. Only the widget's Refresh button calls it. |
+
+Both return `structuredContent` (the render-only data the card hydrates from) and advertise
+`_meta.ui.resourceUri = "ui://shop/order-card"`.
+
+## Why the resource is a stub
+
+The app renders the widget natively, so the served `ui://shop/order-card` resource is only a stub.
+It must exist anyway, because the MCP client fetches the advertised resource when a tool advertises
+one. A web host that wanted the widget as HTML would render that resource instead.

--- a/examples/mcp-shop-server/requirements.txt
+++ b/examples/mcp-shop-server/requirements.txt
@@ -1,0 +1,2 @@
+# Tested with mcp 1.28.1. `meta=` on @mcp.tool and structured_output need a recent build.
+mcp>=1.28.0

--- a/examples/mcp-shop-server/shop_server.py
+++ b/examples/mcp-shop-server/shop_server.py
@@ -18,12 +18,16 @@ the served `ui://` resource is only a stub — but it must exist, because the cl
 advertised resource when a tool advertises one.
 """
 
+import os
+
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel
 
 ORDER_CARD_URI = "ui://shop/order-card"
 
-mcp = FastMCP("shop", host="127.0.0.1", port=8000)
+# Loopback by default (Simulator reaches it). For a physical device, bind to the LAN with
+# `HOST=0.0.0.0 python shop_server.py` and point the app at your Mac's LAN IP.
+mcp = FastMCP("shop", host=os.environ.get("HOST", "127.0.0.1"), port=int(os.environ.get("PORT", "8000")))
 
 
 class Order(BaseModel):

--- a/examples/mcp-shop-server/shop_server.py
+++ b/examples/mcp-shop-server/shop_server.py
@@ -1,0 +1,80 @@
+"""A tiny MCP shop server for the ChatGPTStyleChat sample.
+
+Exposes an order-lookup tool that advertises a UI widget, over streamable HTTP so a native app
+(the Swift ChatGPTStyleChat sample) can point at it with `MCPServer(url: "http://…/mcp")`.
+
+    pip install -r requirements.txt
+    python shop_server.py            # serves on http://127.0.0.1:8000/mcp
+
+Tools:
+  get_order(orderId)     → order status + delivery estimate. Advertises the widget and is
+                           callable by the model.
+  refresh_order(orderId) → same, marked app-only (visibility ["app"]) so it is never offered to
+                           the model — only the app's Refresh button calls it.
+
+Both return `structuredContent` (the render-only data the native card hydrates from) and advertise
+`_meta.ui.resourceUri = "ui://shop/order-card"`. The app renders that widget as native SwiftUI, so
+the served `ui://` resource is only a stub — but it must exist, because the client fetches the
+advertised resource when a tool advertises one.
+"""
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel
+
+ORDER_CARD_URI = "ui://shop/order-card"
+
+mcp = FastMCP("shop", host="127.0.0.1", port=8000)
+
+
+class Order(BaseModel):
+    """The order shape. A typed return makes FastMCP emit it as `structuredContent` — the render-only
+    data the native card hydrates from."""
+
+    orderId: str
+    status: str
+    eta: str
+    carrier: str
+    items: list[str]
+
+
+def _order(order_id: str, refreshed: bool) -> Order:
+    """The faked backend — replace with a real API/database call."""
+    return Order(
+        orderId=order_id,
+        status="Out for delivery" if refreshed else "In transit",
+        eta="Today, 6:00 PM" if refreshed else "2026-07-02",
+        carrier="FastShip",
+        items=["Wireless Headphones", "USB-C Cable"],
+    )
+
+
+@mcp.tool(
+    name="get_order",
+    description="Look up an order's status and delivery estimate.",
+    meta={"ui": {"resourceUri": ORDER_CARD_URI, "visibility": ["model", "app"]}},
+    structured_output=True,
+)
+def get_order(orderId: str) -> Order:
+    return _order(orderId, refreshed=False)
+
+
+@mcp.tool(
+    name="refresh_order",
+    description="Refresh the order card with the latest status.",
+    meta={"ui": {"resourceUri": ORDER_CARD_URI, "visibility": ["app"]}},  # app-only: hidden from the model
+    structured_output=True,
+)
+def refresh_order(orderId: str) -> Order:
+    return _order(orderId, refreshed=True)
+
+
+@mcp.resource(ORDER_CARD_URI, mime_type="text/html;profile=mcp-app")
+def order_card_resource() -> str:
+    """The widget resource. The native app renders the card from `structuredContent` and ignores
+    this body — it exists only because the client fetches the advertised resource. (A web host that
+    wanted the widget as HTML would render this instead.)"""
+    return "<!-- ui://shop/order-card — rendered natively by the app from structuredContent -->"
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat.xcodeproj/project.pbxproj
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A100000000000000000000B9 /* AgentSquad in Frameworks */ = {isa = PBXBuildFile; productRef = A100000000000000000000B8 /* AgentSquad */; };
+		A100000000000000000000BB /* AgentSquadMCP in Frameworks */ = {isa = PBXBuildFile; productRef = A100000000000000000000BA /* AgentSquadMCP */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -20,6 +21,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A100000000000000000000B9 /* AgentSquad in Frameworks */,
+				A100000000000000000000BB /* AgentSquadMCP in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,6 +65,7 @@
 			name = ChatGPTStyleChat;
 			packageProductDependencies = (
 				A100000000000000000000B8 /* AgentSquad */,
+				A100000000000000000000BA /* AgentSquadMCP */,
 			);
 			productName = ChatGPTStyleChat;
 			productReference = A100000000000000000000A5 /* ChatGPTStyleChat.app */;
@@ -336,6 +339,10 @@
 		A100000000000000000000B8 /* AgentSquad */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AgentSquad;
+		};
+		A100000000000000000000BA /* AgentSquadMCP */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AgentSquadMCP;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ChatViewModel.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/ChatViewModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AgentSquad
+import AgentSquadMCP
 
 struct ChatItem: Identifiable {
     let id = UUID()
@@ -17,13 +18,22 @@ final class ChatViewModel: ObservableObject {
 
     private let withWidgets: Orchestrator    // GroundedAgent with ui: .forward
     private let textOnly: Orchestrator       // GroundedAgent with ui: .suppress
-    private let shopProvider = ShopToolProvider()
+    private let toolProvider: any ToolProvider
 
     init() {
         let key       = Config.openAIKey
         let brain     = ChatCompletionsClient(model: "gpt-4o", apiKey: key)       // fetches
         let presenter = ChatCompletionsClient(model: "gpt-4o-mini", apiKey: key)  // talks
-        let provider  = shopProvider
+
+        // Native in-app tools by default; a remote MCP server when Config.mcpServerURL is set.
+        // Either way it's just a ToolProvider — the GroundedAgent doesn't care where tools live.
+        let provider: any ToolProvider
+        if let mcpURL = Config.mcpServerURL {
+            provider = MCPServer(url: mcpURL)   // streamable HTTP; connects lazily on first use
+        } else {
+            provider = ShopToolProvider()
+        }
+        toolProvider = provider
 
         let gathererPrompt = """
             You are the data brain of a shopping assistant.
@@ -101,7 +111,7 @@ final class ChatViewModel: ObservableObject {
     func handleWidgetTool(_ name: String, arguments: JSONValue, for itemID: UUID) {
         Task {
             guard let index = items.firstIndex(where: { $0.id == itemID }) else { return }
-            if let payload = try? await shopProvider.call(name, arguments: arguments).ui {
+            if let payload = try? await toolProvider.call(name, arguments: arguments).ui {
                 items[index].widget = payload
             }
         }

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/Config.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/Config.swift
@@ -12,6 +12,7 @@ enum Config {
 
     /// When set, tools come from a remote MCP server (streamable HTTP) instead of the in-app
     /// `ShopToolProvider` — e.g. the sample at `examples/mcp-shop-server`. Nil = native provider.
-    /// On the iOS Simulator `127.0.0.1` reaches your Mac; on a device use your Mac's LAN IP.
+    /// The Simulator reaches your Mac at `127.0.0.1`; for a physical device, start the server with
+    /// `HOST=0.0.0.0` and use your Mac's LAN IP here.
     static let mcpServerURL: String? = nil   // "http://127.0.0.1:8000/mcp"
 }

--- a/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/Config.swift
+++ b/examples/swift/ChatGPTStyleChat/ChatGPTStyleChat/Config.swift
@@ -9,4 +9,9 @@ enum Config {
         }
         return "PASTE_YOUR_OPENAI_KEY_HERE"
     }()
+
+    /// When set, tools come from a remote MCP server (streamable HTTP) instead of the in-app
+    /// `ShopToolProvider` — e.g. the sample at `examples/mcp-shop-server`. Nil = native provider.
+    /// On the iOS Simulator `127.0.0.1` reaches your Mac; on a device use your Mac's LAN IP.
+    static let mcpServerURL: String? = nil   // "http://127.0.0.1:8000/mcp"
 }

--- a/examples/swift/ChatGPTStyleChat/README.md
+++ b/examples/swift/ChatGPTStyleChat/README.md
@@ -47,12 +47,27 @@ framework.
   was never involved — the widget called the `.app`-only `refresh_order` tool directly.
 - Flip the **Widgets** toggle off and ask again → the *same* grounded answer, as text only.
 
+## Tools from a remote MCP server (optional)
+
+By default the tools are native, in-app Swift code (`ShopToolProvider`). The same chat works
+unchanged against a remote **MCP server** — the GroundedAgent doesn't care where tools live. Set the
+toggle in `Config.swift`:
+
+```swift
+static let mcpServerURL: String? = "http://127.0.0.1:8000/mcp"   // nil = native ShopToolProvider
+```
+
+A runnable server is included at [`examples/mcp-shop-server`](../../mcp-shop-server) — it exposes the
+same `get_order` / `refresh_order` tools and advertises the same `ui://shop/order-card` widget, so
+the native `OrderCardView` renders identically. Start it with `python shop_server.py`, set the URL
+above, and run. On the Simulator `127.0.0.1` reaches your Mac; on a device use your Mac's LAN IP.
+
 ## How it maps to the article
 
 | File | Article section |
 |------|-----------------|
 | `ChatGPTStyleChatApp.swift` | the `@main` entry point |
-| `Config.swift` | the API key plumbing (Prerequisites) |
+| `Config.swift` | the API key plumbing (Prerequisites) + the optional `mcpServerURL` toggle |
 | `ShopToolProvider.swift` | **Step 3** — a tool that returns a widget (`get_order`) + an `.app`-only tool (`refresh_order`) |
 | `OrderCardView.swift` | **Step 6** — the native SwiftUI widget for `ui://shop/order-card`, hydrated from `structuredContent` |
 | `ChatViewModel.swift` | **Step 2 & 4** — the GroundedAgent, prompts, and the `.forward`/`.suppress` toggle; the widget→app callback |

--- a/examples/swift/ChatGPTStyleChat/README.md
+++ b/examples/swift/ChatGPTStyleChat/README.md
@@ -60,7 +60,8 @@ static let mcpServerURL: String? = "http://127.0.0.1:8000/mcp"   // nil = native
 A runnable server is included at [`examples/mcp-shop-server`](../../mcp-shop-server) — it exposes the
 same `get_order` / `refresh_order` tools and advertises the same `ui://shop/order-card` widget, so
 the native `OrderCardView` renders identically. Start it with `python shop_server.py`, set the URL
-above, and run. On the Simulator `127.0.0.1` reaches your Mac; on a device use your Mac's LAN IP.
+above, and run. On the Simulator `127.0.0.1` reaches your Mac; for a physical device start the server
+with `HOST=0.0.0.0 python shop_server.py` and use your Mac's LAN IP in the URL.
 
 ## How it maps to the article
 


### PR DESCRIPTION
## Issue Link
Closes #608

## Summary
Adds a runnable sample MCP server and lets the ChatGPTStyleChat sample optionally point at it, so the same GroundedAgent + native-widget flow can be demonstrated against a remote MCP server (streamable HTTP), not only in-app tools.

## Changes
- `examples/mcp-shop-server/` — a small Python (FastMCP) server: `get_order` (model+app) and `refresh_order` (app-only) tools, each advertising `_meta.ui.resourceUri = ui://shop/order-card` with visibility, returning `structuredContent`. Serves a stub `ui://` resource (the app renders the card natively). Includes `requirements.txt` and `README.md`.
- `examples/swift/ChatGPTStyleChat` — added `Config.mcpServerURL` (nil = native provider); `ChatViewModel` builds `MCPServer(url:)` when set, else `ShopToolProvider()`, as `any ToolProvider`; linked the `AgentSquadMCP` product. README documents the toggle.

## User experience
Default behaviour is unchanged — tools stay native in-app Swift. Set `Config.mcpServerURL` and run `python shop_server.py` to have the exact same chat and order-card widget served by a remote MCP server instead.

## Checklist
- [x] Backward compatible (nil toggle = unchanged native path)
- [x] Swift app builds (xcodebuild, generic/platform=iOS)
- [x] MCP server verified standalone (list_tools _meta.ui, call_tool structuredContent, read_resource)
- [x] Docs updated (sample README + server README)
- [x] swift-expert reviewed

Code written by Claude (Opus 4.8), architected and approved by @cornelcroi.