### PR TITLE
fix(python): cap mcp dependency to <2

### DIFF
--- a/docs/src/content/docs/agents/mcp-tool-provider.mdx
+++ b/docs/src/content/docs/agents/mcp-tool-provider.mdx
@@ -30,7 +30,7 @@ npm install @modelcontextprotocol/sdk
 ```bash
 pip install "agent-squad[mcp]"
 ```
-The `mcp` extra is optional — it is not pulled in when you install the base package.
+The `mcp` extra is optional — it is not pulled in when you install the base package. It installs the MCP SDK 1.x (`mcp>=1.0.0,<2`); the SDK's 2.x line is a breaking release and is not supported yet (tracked in [#634](https://github.com/2FastLabs/agent-squad/issues/634)).
   </TabItem>
 </Tabs>
 

--- a/examples/mcp-shop-server/requirements.txt
+++ b/examples/mcp-shop-server/requirements.txt
@@ -1,2 +1,3 @@
 # Tested with mcp 1.28.1. `meta=` on @mcp.tool and structured_output need a recent build.
-mcp>=1.28.0
+# Capped to <2: mcp 2.0.0 is a breaking release (FastMCP renamed, snake_case types).
+mcp>=1.28.0,<2

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -34,7 +34,7 @@ strands-agents =
 dakera =
     dakera>=0.12.8
 mcp =
-    mcp>=1.0.0
+    mcp>=1.0.0,<2
 
 all =
     anthropic>=0.40.0
@@ -42,7 +42,7 @@ all =
     boto3>=1.36.18
     libsql-client>=0.3.1
     dakera>=0.12.8
-    mcp>=1.0.0
+    mcp>=1.0.0,<2
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## Issue Link

Closes #631

## Summary

`mcp` 2.0.0 shipped on PyPI on 2026-07-28 under the same package name as a breaking release (type attributes renamed camelCase → snake_case, `FastMCP` renamed). Our unbounded `mcp>=1.0.0` extra now resolves to 2.x on fresh installs, and `MCPToolProvider` breaks: `tool.inputSchema` raises `AttributeError`, and `getattr(result, "isError", False)` silently masks tool errors. This caps the range to `<2`, the SDK maintainers' own recommendation for unmigrated libraries. Support for 2.x lands later via #634 (dual-major), which lifts this cap.

## Changes

- `python/setup.cfg`: `mcp>=1.0.0,<2` in both the `mcp` and `all` extras
- `examples/mcp-shop-server/requirements.txt`: `mcp>=1.28.0,<2`
- `docs/agents/mcp-tool-provider.mdx`: note in the Python install section that the extra installs the 1.x SDK, with a pointer to #634

## User experience

`pip install "agent-squad[mcp]"` resolves to `mcp` 1.29.0 (last 1.x) and works again. No code change, no behavior change for anyone already on 1.x.

Note for release: the cap reaches users only with the next PyPI release — until then fresh installs still pull the broken 2.0.0.

## Checklist

- [x] Issue linked
- [x] Docs updated
- [x] No breaking changes (dependency range narrowed only to exclude versions that never worked)
- [x] Backward compatible

Code written by Claude (Fable 5), architected and approved by @cornelcroi.