### PR TITLE
feat(examples): upgrade mcp-shop-server to mcp 2.x, add TS/Python consumption snippets

### DIFF
--- a/examples/mcp-shop-server/README.md
+++ b/examples/mcp-shop-server/README.md
@@ -4,11 +4,16 @@ A tiny [MCP](https://modelcontextprotocol.io) server for the [ChatGPTStyleChat](
 Swift sample. It exposes an order-lookup tool that advertises a **UI widget**, over streamable HTTP,
 so the native app can point at it instead of its built-in in-app tool.
 
+Built on `mcp` 2.x, so it serves MCP protocol **2026-07-28** and still answers older clients
+through the legacy handshake — the same server works for every consumer below, old or new.
+
 It shows the same contract ChatGPT Apps use: a tool returns `structuredContent` and advertises
 `_meta.ui.resourceUri`. The app renders that widget as a native SwiftUI card, hydrated from the
 tool's data — no HTML, no web view.
 
 ## Run it
+
+Requires Python >= 3.10 (the `mcp` 2.x floor).
 
 ```bash
 # Optional: Set up a virtual environment
@@ -17,6 +22,31 @@ source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 pip install -r requirements.txt
 python shop_server.py                   # serves on http://127.0.0.1:8000/mcp (loopback)
 HOST=0.0.0.0 python shop_server.py      # bind to the LAN, for a physical device
+```
+
+## Consume it from agent-squad (TypeScript / Python)
+
+`MCPToolProvider` connects over the `streamable-http` transport; the protocol era is negotiated
+per server, so nothing else is configured. With the v2 SDKs installed
+(`@modelcontextprotocol/client` / `mcp>=2`) the session runs on protocol 2026-07-28; with the v1
+SDKs it falls back to the legacy handshake — same code either way.
+
+```typescript
+import { MCPToolProvider } from "agent-squad";
+
+const provider = await MCPToolProvider.create([
+  { type: "streamable-http", url: "http://127.0.0.1:8000/mcp" },
+]);
+// get_order is offered to the model; refresh_order stays app-only.
+```
+
+```python
+from agent_squad.tools import MCPToolProvider, MCPServerConfig
+
+provider = await MCPToolProvider.create([
+    MCPServerConfig(type="streamable-http", url="http://127.0.0.1:8000/mcp"),
+])
+# get_order is offered to the model; refresh_order stays app-only.
 ```
 
 ## Point the app at it

--- a/examples/mcp-shop-server/requirements.txt
+++ b/examples/mcp-shop-server/requirements.txt
@@ -1,3 +1,2 @@
-# Tested with mcp 1.28.1. `meta=` on @mcp.tool and structured_output need a recent build.
-# Capped to <2: mcp 2.0.0 is a breaking release (FastMCP renamed, snake_case types).
-mcp>=1.28.0,<2
+# mcp 2.x (MCPServer) serves MCP protocol 2026-07-28 and answers legacy clients too.
+mcp>=2.0.0

--- a/examples/mcp-shop-server/shop_server.py
+++ b/examples/mcp-shop-server/shop_server.py
@@ -1,7 +1,7 @@
 """A tiny MCP shop server for the ChatGPTStyleChat sample.
 
 Exposes an order-lookup tool that advertises a UI widget, over streamable HTTP so a native app
-(the Swift ChatGPTStyleChat sample) can point at it with `MCPServer(url: "http://…/mcp")`.
+(the Swift ChatGPTStyleChat sample) can point at it with AgentSquadMCP's `MCPServer(url: "http://…/mcp")`.
 
     pip install -r requirements.txt
     python shop_server.py            # serves on http://127.0.0.1:8000/mcp
@@ -20,19 +20,17 @@ advertised resource when a tool advertises one.
 
 import os
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 from pydantic import BaseModel
 
 ORDER_CARD_URI = "ui://shop/order-card"
 
-# Loopback by default (Simulator reaches it). For a physical device, bind to the LAN with
-# `HOST=0.0.0.0 python shop_server.py` and point the app at your Mac's LAN IP.
-mcp = FastMCP("shop", host=os.environ.get("HOST", "127.0.0.1"), port=int(os.environ.get("PORT", "8000")))
+mcp = MCPServer("shop")
 
 
 class Order(BaseModel):
-    """The order shape. A typed return makes FastMCP emit it as `structuredContent` — the render-only
-    data the native card hydrates from."""
+    """The order shape. A typed return makes the server emit it as `structuredContent` — the
+    render-only data the native card hydrates from."""
 
     orderId: str
     status: str
@@ -81,4 +79,10 @@ def order_card_resource() -> str:
 
 
 if __name__ == "__main__":
-    mcp.run(transport="streamable-http")
+    # Loopback by default (Simulator reaches it). For a physical device, bind to the LAN with
+    # `HOST=0.0.0.0 python shop_server.py` and point the app at your Mac's LAN IP.
+    mcp.run(
+        transport="streamable-http",
+        host=os.environ.get("HOST", "127.0.0.1"),
+        port=int(os.environ.get("PORT", "8000")),
+    )


### PR DESCRIPTION
## Issue Link

Closes #635

## Summary

Final piece of the MCP 2026-07-28 series (#631–#634). The shop server example moves to `mcp` 2.x (`MCPServer`), so it serves protocol 2026-07-28 while still answering legacy clients — the Swift ChatGPTStyleChat sample keeps working unchanged. The README now shows how to consume it from agent-squad in TypeScript and Python over `streamable-http`.

## Changes

- `shop_server.py`: `FastMCP` → `MCPServer`; host/port moved from the constructor to `run()` (the v2 API); decorators (`meta=`, `structured_output=`) unchanged — verified against the installed 2.0.0.
- `requirements.txt`: `mcp>=2.0.0`.
- `README.md`: dual-era note, TS + Python `MCPToolProvider` snippets, Python >= 3.10 note.

## Verification

Live end-to-end, all four combinations exercised against this server: agent-squad's `MCPToolProvider` on mcp 2.0 negotiated the modern era (stateless POSTs); on mcp 1.29 the server answered the legacy handshake (protocol 2025-11-25, session ID). Model-visible filtering (`get_order` visible, `refresh_order` app-only), widget URI, and `structuredContent` verified on both. The reviewer independently reproduced this, including a raw legacy `initialize` (2025-06-18) and a modern `server/discover` (2026-07-28) against the same process.

python-expert review: APPROVED.

## Release notes draft for the series (no CHANGELOG file exists in the repo — use for the next release, suggested 1.2.0 / TS minor)

- MCP protocol **2026-07-28** supported in both trees via the v2 SDKs, auto-negotiated per server; v1 SDK setups unchanged (#633, #634)
- New `streamable-http` transport in `MCPServerConfig` (#632)
- Python `agent-squad[mcp]` accepts `mcp` 1.x **and** 2.x (#631, #634); fresh installs resolve to 2.x
- Fixed: tool errors and structured content from mcp 2.x results are now read correctly
- Known issue: TS `sse` custom headers (#640, pre-existing)

## Checklist

- [x] Issue linked
- [x] Docs/README updated with usage examples
- [x] Backward compatible (example only; server still serves legacy clients)

Code written by Claude (Fable 5), architected and approved by @cornelcroi.