### PR TITLE
fix(docs): add summarizing storage page to the Swift sidebar

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -250,6 +250,7 @@ export default defineConfig({
 											{ label: 'File', slug: 'swift/storage/built-in/file' },
 											{ label: 'Device (SwiftData)', slug: 'swift/storage/built-in/device' },
 											{ label: 'Transforming (PII scrub)', slug: 'swift/storage/built-in/transforming' },
+											{ label: 'Summarizing', slug: 'swift/storage/built-in/summarizing' },
 										],
 									},
 									{ label: 'Custom store', slug: 'swift/storage/custom' },


### PR DESCRIPTION
## Issue Link

Closes #645

## Summary

Every docs deploy on main has failed since ~July 14 with `Caught error rendering /swift/storage/built-in/summarizing`. The page was added without a sidebar entry, and the `starlight-sidebar-topics` middleware throws for pages not attached to any topic. The live site is two weeks stale as a result — including all the MCP docs from #632–#634.

## Changes

- One line in `docs/astro.config.mjs`: `Summarizing` entry next to its storage siblings in the Swift topic.

## Verification

Full `astro build` run locally: 111 pages, completes cleanly (was failing on this exact page before the change).

## Checklist

- [x] Issue linked
- [x] Verified locally

Code written by Claude (Fable 5), architected and approved by @cornelcroi.